### PR TITLE
feat: implement memory-efficient CSV export endpoint

### DIFF
--- a/aggregator-service/db.py
+++ b/aggregator-service/db.py
@@ -211,3 +211,50 @@ async def get_stats(pool: asyncpg.Pool) -> Dict[str, Any]:
         "by_source": {r["key"]: r["cnt"] for r in source_rows},
         "by_status": {r["key"]: r["cnt"] for r in status_rows},
     }
+
+
+async def stream_jobs(
+    pool: asyncpg.Pool,
+    *,
+    role: Optional[str] = None,
+    stack: Optional[List[str]] = None,
+    status: Optional[str] = None,
+    sort: str = "latest",
+):
+    """
+    Stream jobs with optional filters and sorting using server-side cursor.
+
+    Yields chunks of records. Use inside a transaction for cursor stability.
+    """
+    conditions: List[str] = []
+    params: List[Any] = []
+    idx = 1
+
+    if role:
+        conditions.append(f"role ILIKE ${idx}")
+        params.append(f"%{role}%")
+        idx += 1
+
+    if stack:
+        conditions.append(f"stack @> ${idx}::text[]")
+        params.append(stack)
+        idx += 1
+
+    if status:
+        conditions.append(f"status = ${idx}")
+        params.append(status)
+        idx += 1
+
+    where_clause = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+    order = "DESC NULLS LAST" if sort == "latest" else "ASC NULLS LAST"
+
+    sql = f"""
+        SELECT * FROM jobs
+        {where_clause}
+        ORDER BY posted_at {order}
+    """
+
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            async for record in conn.cursor(sql, *params, prefetch=1000):
+                yield record

--- a/aggregator-service/main.py
+++ b/aggregator-service/main.py
@@ -4,6 +4,7 @@ main.py — FastAPI application for the Job Aggregator Service.
 Endpoints
 ---------
 GET  /jobs                   List jobs with optional filters
+GET  /jobs/export?format=csv Export jobs as CSV with optional filters
 GET  /jobs/{id}              Fetch a single job by UUID
 PATCH /jobs/{id}/status      Update a job's status
 GET  /stats                  Aggregate counts by source and status
@@ -13,6 +14,8 @@ GET  /health                 Liveness / readiness probe
 from __future__ import annotations
 
 import asyncio
+import csv
+import io
 import logging
 import os
 from contextlib import asynccontextmanager
@@ -20,7 +23,7 @@ from typing import List, Optional
 from uuid import UUID
 
 from fastapi import FastAPI, HTTPException, Query
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 
 import db as database
 import consumer as stream_consumer
@@ -126,6 +129,86 @@ async def list_jobs(
         limit=limit,
     )
     return [JobOut(**_record_to_dict(r)) for r in rows]
+
+
+@app.get("/jobs/export", tags=["jobs"])
+async def export_jobs_csv(
+    role: Optional[str] = Query(None, description="Substring match on role title"),
+    stack: Optional[str] = Query(
+        None,
+        description="Comma-separated tech tags; returns jobs whose stack contains ALL of them",
+    ),
+    status: Optional[str] = Query(None, description="Filter by status: new | applied | ignored"),
+    sort: str = Query("latest", description="Sort order: latest | oldest"),
+    format: str = Query("csv", description="Export format (only csv supported)"),
+):
+    if format != "csv":
+        raise HTTPException(status_code=400, detail="Only csv format is supported")
+    if sort not in ("latest", "oldest"):
+        raise HTTPException(status_code=400, detail="sort must be 'latest' or 'oldest'")
+    if status and status not in ("new", "applied", "ignored"):
+        raise HTTPException(status_code=400, detail="status must be new | applied | ignored")
+
+    stack_list = [s.strip() for s in stack.split(",")] if stack else None
+
+    pool = await database.get_pool()
+
+    async def generate_csv():
+        buffer = io.StringIO()
+        writer = csv.writer(buffer)
+        
+        # Write header
+        writer.writerow([
+            "id", "company", "role", "source", "url", "stack", "product", 
+            "location", "posted_at", "status", "created_at"
+        ])
+        yield buffer.getvalue()
+        buffer.truncate(0)
+        buffer.seek(0)
+        
+        # Stream data in chunks
+        chunk_size = 1000
+        chunk = []
+        async for record in database.stream_jobs(
+            pool,
+            role=role,
+            stack=stack_list,
+            status=status,
+            sort=sort,
+        ):
+            row = _record_to_dict(record)
+            csv_row = [
+                str(row["id"]),
+                row["company"],
+                row["role"],
+                row["source"] or "",
+                row["url"] or "",
+                ",".join(row["stack"]) if row["stack"] else "",
+                row["product"] or "",
+                row["location"] or "",
+                row["posted_at"].isoformat() if row["posted_at"] else "",
+                row["status"],
+                row["created_at"].isoformat(),
+            ]
+            chunk.append(csv_row)
+            
+            if len(chunk) >= chunk_size:
+                writer.writerows(chunk)
+                yield buffer.getvalue()
+                buffer.truncate(0)
+                buffer.seek(0)
+                chunk = []
+        
+        # Yield remaining rows
+        if chunk:
+            writer.writerows(chunk)
+            yield buffer.getvalue()
+
+    return StreamingResponse(
+        generate_csv(),
+        media_type="text/csv",
+        headers={"Content-Disposition": "attachment; filename=jobs.csv"}
+    )
 
 
 @app.get("/jobs/{job_id}", response_model=JobOut, tags=["jobs"])

--- a/gateway/main.py
+++ b/gateway/main.py
@@ -127,6 +127,11 @@ async def proxy_jobs(request: Request):
     return await proxy.proxy_request(request, f"{proxy.AGGREGATOR_URL}/jobs")
 
 
+@app.api_route("/api/jobs/export", methods=["GET"], tags=["proxy"])
+async def proxy_jobs_export(request: Request):
+    return await proxy.proxy_request(request, f"{proxy.AGGREGATOR_URL}/jobs/export")
+
+
 @app.api_route("/api/jobs/{path:path}", methods=["GET", "POST", "PATCH", "DELETE"], tags=["proxy"])
 async def proxy_jobs_path(path: str, request: Request):
     return await proxy.proxy_request(request, f"{proxy.AGGREGATOR_URL}/jobs/{path}")

--- a/tests/integration/test_aggregator_export.py
+++ b/tests/integration/test_aggregator_export.py
@@ -1,0 +1,195 @@
+"""
+Layer 2 — Integration tests: Aggregator service CSV export (real Postgres)
+
+Uses testcontainers-python to spin up a real postgres:15-alpine container
+for the test session, then exercises the CSV export endpoint with streaming.
+
+Run with:
+  cd tests
+  pytest integration/test_aggregator_export.py -v
+
+Requires: pip install pytest pytest-asyncio testcontainers asyncpg httpx
+"""
+
+import csv
+import io
+import pytest
+import asyncpg
+import sys
+import os
+from httpx import AsyncClient
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "aggregator-service"))
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session")
+def postgres_url():
+    """Start a real Postgres container for the entire test session."""
+    try:
+        from testcontainers.postgres import PostgresContainer
+    except ImportError:
+        pytest.skip("testcontainers not installed — run: pip install testcontainers")
+
+    with PostgresContainer("postgres:15-alpine") as pg:
+        # testcontainers exposes a SQLAlchemy-style URL; asyncpg needs postgresql://
+        url = pg.get_connection_url().replace("postgresql+psycopg2://", "postgresql://")
+        yield url
+
+
+@pytest.fixture(scope="session")
+def event_loop():
+    """Single event loop for the session (required by pytest-asyncio)."""
+    import asyncio
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture(scope="session")
+async def pg_pool(postgres_url):
+    """Create a real asyncpg pool and initialise the schema once per session."""
+    import db
+
+    # Point the module at the container
+    os.environ["DATABASE_URL"] = postgres_url
+    pool = await asyncpg.create_pool(dsn=postgres_url, min_size=1, max_size=5)
+    # Run the schema DDL directly (mirrors db._init_schema)
+    async with pool.acquire() as conn:
+        await conn.execute(db._SCHEMA_SQL)
+    yield pool
+    await pool.close()
+
+
+@pytest.fixture(scope="session")
+async def test_app(pg_pool):
+    """Create a FastAPI test app with the pool."""
+    from fastapi import FastAPI
+    import main
+    import db
+
+    # Override the pool creation
+    db._pool = pg_pool
+    app = main.app
+    yield app
+
+
+@pytest.fixture
+async def client(test_app):
+    """HTTP client for testing the FastAPI app."""
+    async with AsyncClient(app=test_app, base_url="http://test") as client:
+        yield client
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _insert(pool, **overrides):
+    """Insert a job with sensible defaults, return the record."""
+    import db
+    defaults = dict(
+        company="Zepto",
+        role="Backend Engineer",
+        source="remotive",
+        url="https://zepto.com/jobs/1",
+        stack=["Go", "Postgres"],
+        product="Quick commerce",
+        location="Bengaluru",
+        posted_at=None,
+    )
+    defaults.update(overrides)
+    return await db.insert_job(pool, **defaults)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestExportJobsCSV:
+    async def test_export_empty_csv(self, client):
+        """Test CSV export with no jobs returns only header."""
+        response = await client.get("/jobs/export?format=csv")
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "text/csv"
+        assert "attachment; filename=jobs.csv" in response.headers["content-disposition"]
+        
+        content = response.text
+        reader = csv.reader(io.StringIO(content))
+        rows = list(reader)
+        assert len(rows) == 1  # Only header
+        assert rows[0] == ["id", "company", "role", "source", "url", "stack", "product", "location", "posted_at", "status", "created_at"]
+
+    async def test_export_with_jobs(self, client, pg_pool):
+        """Test CSV export with some jobs."""
+        # Insert test jobs
+        await _insert(pg_pool, company="Zepto", role="Backend Engineer", stack=["Go", "Postgres"])
+        await _insert(pg_pool, company="Swiggy", role="Frontend Engineer", stack=["React", "TypeScript"])
+        
+        response = await client.get("/jobs/export?format=csv")
+        assert response.status_code == 200
+        
+        content = response.text
+        reader = csv.reader(io.StringIO(content))
+        rows = list(reader)
+        assert len(rows) == 3  # Header + 2 jobs
+        assert rows[0] == ["id", "company", "role", "source", "url", "stack", "product", "location", "posted_at", "status", "created_at"]
+        
+        # Check first job
+        assert rows[1][1] == "Zepto"
+        assert rows[1][2] == "Backend Engineer"
+        assert rows[1][5] == "Go,Postgres"
+        assert rows[1][9] == "new"
+        
+        # Check second job
+        assert rows[2][1] == "Swiggy"
+        assert rows[2][2] == "Frontend Engineer"
+        assert rows[2][5] == "React,TypeScript"
+
+    async def test_export_with_filters(self, client, pg_pool):
+        """Test CSV export respects filters."""
+        await _insert(pg_pool, company="Zepto", role="Backend Engineer", stack=["Go", "Postgres"])
+        await _insert(pg_pool, company="Swiggy", role="Frontend Engineer", stack=["React", "TypeScript"])
+        
+        # Filter by role
+        response = await client.get("/jobs/export?format=csv&role=Backend")
+        assert response.status_code == 200
+        
+        content = response.text
+        reader = csv.reader(io.StringIO(content))
+        rows = list(reader)
+        assert len(rows) == 2  # Header + 1 job
+        assert rows[1][1] == "Zepto"
+
+    async def test_export_large_dataset_memory_efficient(self, client, pg_pool):
+        """Test that export handles large datasets without excessive memory usage."""
+        # Insert many jobs
+        jobs = []
+        for i in range(10000):
+            jobs.append(_insert(pg_pool, company=f"Company{i}", role=f"Role{i}", stack=["Python"]))
+        
+        await asyncio.gather(*jobs)
+        
+        response = await client.get("/jobs/export?format=csv")
+        assert response.status_code == 200
+        
+        # Count lines in response
+        content = response.text
+        line_count = content.count('\n')
+        assert line_count == 10001  # 10000 jobs + header
+        
+        # Verify we can parse the CSV
+        reader = csv.reader(io.StringIO(content))
+        rows = list(reader)
+        assert len(rows) == 10001
+        assert rows[0][0] == "id"
+        assert rows[1][1] == "Company0"
+
+    async def test_export_invalid_format(self, client):
+        """Test that invalid format returns 400."""
+        response = await client.get("/jobs/export?format=json")
+        assert response.status_code == 400
+        assert "Only csv format is supported" in response.json()["detail"]

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -7,6 +7,7 @@ pytest-cov>=5.0.0           # coverage reporting
 
 # Layer 2 — integration tests
 testcontainers[postgres,redis]>=4.5.0  # real Postgres + Redis containers
+httpx>=0.25.0                         # HTTP client for testing FastAPI apps
 
 # Service runtime deps (needed so tests can import service modules)
 asyncpg>=0.29.0


### PR DESCRIPTION
Fixes #9 
Hi @sharmavaibhav31,
As discussed, here is the skeleton for the CSV export endpoint.
Implementation Details:
- Add /jobs/export?format=csv endpoint to aggregator service
- Implement streaming CSV generation with asyncpg server-side cursor
- Add gateway proxy route for CSV export
- Add comprehensive tests for CSV export functionality
- Update test requirements to include httpx for testing

The implementation uses asyncpg server-side cursor in a transaction block to stream data in batches of 1000 records, keeping memory usage at O(1). CSV generation accumulates chunks before yielding to optimize streaming.