### PR TITLE
feat: improve empty state UI, add CSV export button, fix Ollama silen…

### DIFF
--- a/email-generator-service/ollama_client.py
+++ b/email-generator-service/ollama_client.py
@@ -42,7 +42,11 @@ async def _detect_available_model(client: httpx.AsyncClient) -> Optional[str]:
                 if model in available:
                     return model
     except Exception:
-        pass
+        logger.warning(
+            "[Ollama] Could not reach Ollama at %s. "
+            "Is Ollama installed and running? Install it from https://ollama.com",
+            OLLAMA_BASE_URL,
+        )
     return None
 
 
@@ -64,7 +68,10 @@ async def generate_observation(product_description: str) -> Optional[str]:
     async with httpx.AsyncClient() as client:
         model = await _detect_available_model(client)
         if model is None:
-            logger.info("[Ollama] No models available or Ollama not running.")
+            logger.warning(
+                "[Ollama] No models available. Run 'ollama pull mistral' to install one, "
+                "or visit https://ollama.com to set up Ollama. Falling back to static observations."
+            )
             return None
 
         logger.info("[Ollama] Using model '%s' for observation generation.", model)

--- a/gateway/dashboard.html
+++ b/gateway/dashboard.html
@@ -847,8 +847,9 @@
         <button class="nav-tab" data-tab="stats">Stats</button>
       </div>
     </div>
-    <button id="btn-scrape">▶ Trigger Scrape</button>
-  </nav>
+  <button id="btn-scrape">▶ Trigger Scrape</button>
+        <button id="btn-export-csv" style="padding:7px 14px;background:var(--surface);color:var(--text);border:1px solid var(--border);border-radius:var(--radius);font-size:13px;font-weight:500;cursor:pointer;" title="Export jobs as CSV">⬇ Export CSV</button>
+      </nav>
 
   <!-- OFFLINE BANNER -->
   <div id="offline-banner">
@@ -1155,7 +1156,23 @@
       const jobs = filteredJobs();
       const grid = document.getElementById('jobs-grid');
       if (!jobs.length) {
-        grid.innerHTML = `<div class="empty" style="grid-column:1/-1"><div class="empty-icon">🔍</div><p>No jobs found. Trigger a scrape to get started.</p></div>`;
+grid.innerHTML = `<div class="empty" style="grid-column:1/-1">
+  <div class="empty-icon">📭</div>
+  <h3 style="font-size:16px;font-weight:600;color:var(--text);margin-bottom:8px">No jobs found yet</h3>
+  <p style="margin-bottom:20px;font-size:13px">Follow these steps to start discovering jobs</p>
+  <div style="display:flex;flex-direction:column;gap:8px;max-width:300px;margin:0 auto 20px;text-align:left">
+    <div style="padding:10px 14px;border:1px solid var(--border);border-radius:var(--radius);font-size:13px">
+      <strong>Step 1</strong> — Click "Trigger Scrape" to start crawling job platforms
+    </div>
+    <div style="padding:10px 14px;border:1px solid var(--border);border-radius:var(--radius);font-size:13px">
+      <strong>Step 2</strong> — Wait ~60 seconds for jobs to appear
+    </div>
+    <div style="padding:10px 14px;border:1px solid var(--border);border-radius:var(--radius);font-size:13px">
+      <strong>Step 3</strong> — Use filters above to narrow down by role or stack
+    </div>
+  </div>
+  <button class="btn-accent" onclick="document.getElementById('btn-scrape').click()">▶ Trigger Scrape</button>
+</div>`;
         return;
       }
       grid.innerHTML = jobs.map(j => `
@@ -1575,6 +1592,28 @@
     document.getElementById('modal-close').addEventListener('click', () => scrapeModal.classList.remove('open'));
     document.getElementById('modal-cancel').addEventListener('click', () => scrapeModal.classList.remove('open'));
     scrapeModal.addEventListener('click', e => { if (e.target === scrapeModal) scrapeModal.classList.remove('open'); });
+    // CSV Export
+  document.getElementById('btn-export-csv').addEventListener('click', async () => {
+    const btn = document.getElementById('btn-export-csv');
+    btn.textContent = '⏳ Exporting...';
+    btn.disabled = true;
+    try {
+      const res = await fetch('/api/jobs/export/csv');
+      if (!res.ok) throw new Error('Export failed');
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `jobs_${new Date().toISOString().slice(0,10)}.csv`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      alert('Export failed: ' + e.message);
+    } finally {
+      btn.textContent = '⬇ Export CSV';
+      btn.disabled = false;
+    }
+  });
     document.addEventListener('keydown', e => { if (e.key === 'Escape') scrapeModal.classList.remove('open'); });
 
     document.getElementById('modal-submit').addEventListener('click', async () => {


### PR DESCRIPTION
Closes #28
Closes #16

Changes:
- Added   Export CSV button in navbar calling /api/jobs/export/csv with loading state and auto-download
- Improved empty state UI with heading, 3-step guide, and Trigger Scrape button  
- Fixed silent  except Exception: pass  in  ollama_client.py → replaced with logger.warning  and actionable install instructions