### PR TITLE
Add referral outreach email template support

### DIFF
--- a/email-generator-service/README.md
+++ b/email-generator-service/README.md
@@ -17,6 +17,7 @@ email-generator-service/
 ├── templates/
 │   ├── cold_outreach.j2       # To hiring manager / engineer (≤150 words)
 │   ├── recruiter_outreach.j2  # To recruiter (≤120 words)
+│   ├── referral_outreach.j2   # To a mutual connection referral contact
 │   └── followup.j2            # Follow-up after no reply (≤80 words)
 ├── requirements.txt
 ├── Dockerfile
@@ -146,6 +147,14 @@ curl -X POST http://localhost:8003/generate \
      -d '{"job_id": "...", "contact_id": "...", "template": "recruiter_outreach",
           "your_name": "Vaibhav Sharma", "your_stack": ["Go", "Kubernetes"],
           "github_url": "https://github.com/sharmavaibhav31", "graduation_year": 2025}'
+
+# Referral outreach
+curl -X POST http://localhost:8003/generate \
+     -H "Content-Type: application/json" \
+     -d '{"job_id": "...", "contact_id": "...", "template": "referral_outreach",
+          "your_name": "Vaibhav Sharma", "your_stack": ["Python", "FastAPI"],
+          "github_url": "https://github.com/sharmavaibhav31",
+          "referred_by": "Priya Menon"}'
 
 # Follow-up (7 days later)
 curl -X POST http://localhost:8003/generate \

--- a/email-generator-service/generator.py
+++ b/email-generator-service/generator.py
@@ -38,7 +38,7 @@ _jinja_env = Environment(
     lstrip_blocks=True,
 )
 
-VALID_TEMPLATES = {"cold_outreach", "recruiter_outreach", "followup"}
+VALID_TEMPLATES = {"cold_outreach", "recruiter_outreach", "referral_outreach", "followup"}
 
 
 # ---------------------------------------------------------------------------
@@ -134,6 +134,7 @@ async def generate_email(
     github_url: str,
     graduation_year: Optional[int] = None,
     availability: Optional[str] = None,
+    referred_by: Optional[str] = None,
 ) -> tuple[str, str]:
     """
     Generate a cold email, returning (subject, body).
@@ -182,6 +183,7 @@ async def generate_email(
         "contact_email":       contact_email,
         "graduation_year":     graduation_year or os.environ.get("GRADUATION_YEAR", "2025"),
         "availability":        availability,
+        "referred_by":         referred_by,
     }
 
     rendered = tmpl.render(**ctx)

--- a/email-generator-service/main.py
+++ b/email-generator-service/main.py
@@ -65,12 +65,13 @@ app = FastAPI(
 class GenerateRequest(BaseModel):
     job_id:          Optional[UUID] = None
     contact_id:      Optional[UUID] = None
-    template:        Literal["cold_outreach", "recruiter_outreach", "followup"]
+    template:        Literal["cold_outreach", "recruiter_outreach", "referral_outreach", "followup"]
     your_name:       str = ""
     your_stack:      List[str] = []
     github_url:      str = ""
     graduation_year: Optional[int] = None
     availability:    Optional[str] = None
+    referred_by:     Optional[str] = None
 
 
 class GenerateResponse(BaseModel):
@@ -140,6 +141,7 @@ async def generate(req: GenerateRequest):
             github_url=github_url,
             graduation_year=req.graduation_year,
             availability=req.availability,
+            referred_by=req.referred_by,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))

--- a/email-generator-service/templates/cold_outreach.j2
+++ b/email-generator-service/templates/cold_outreach.j2
@@ -1,6 +1,6 @@
 Subject: {{ role }} opportunity — {{ your_name }}
 
-Hi {{ contact_name | default("there") }},
+Hi {{ contact_name or "there" }},
 
 I came across {{ company }}'s {{ role }} opening and wanted to reach out directly.
 

--- a/email-generator-service/templates/followup.j2
+++ b/email-generator-service/templates/followup.j2
@@ -1,6 +1,6 @@
 Subject: Re: {{ role }} at {{ company }} — Following up
 
-Hi {{ contact_name | default("there") }},
+Hi {{ contact_name or "there" }},
 
 I wanted to follow up on my email from about a week ago regarding the {{ role }} position at {{ company }}.
 

--- a/email-generator-service/templates/recruiter_outreach.j2
+++ b/email-generator-service/templates/recruiter_outreach.j2
@@ -1,6 +1,6 @@
 Subject: {{ role }} application — {{ your_name }} ({{ graduation_year }} grad)
 
-Hi {{ contact_name | default("there") }},
+Hi {{ contact_name or "there" }},
 
 I'm {{ your_name }}, a {{ graduation_year }} engineering graduate with hands-on experience in {{ your_stack | join(", ") }}. I'm very interested in the **{{ role }}** role at {{ company }}.
 

--- a/email-generator-service/templates/referral_outreach.j2
+++ b/email-generator-service/templates/referral_outreach.j2
@@ -1,0 +1,16 @@
+Subject: {{ role }} at {{ company }} - {{ your_name }}
+
+Hi {{ contact_name or "there" }},
+
+{{ referred_by or "A mutual connection" }} suggested I reach out about the {{ role }} opening at {{ company }}, so I wanted to introduce myself directly.
+
+{{ product_observation }}
+
+My core stack is {{ your_stack | join(", ") }}, and I have been shipping production systems with these tools. The role looks closely aligned with the kind of backend and product engineering work I enjoy.
+
+You can find my work on GitHub: {{ github_url }}
+
+Would you be open to a short conversation this week or next? I would be glad to work around your schedule.
+
+Best,
+{{ your_name }}

--- a/gateway/dashboard.html
+++ b/gateway/dashboard.html
@@ -1262,22 +1262,35 @@
         const tmplSel = `<select id="panel-tmpl" style="height:30px;padding:0 8px;border:1px solid var(--border);border-radius:6px;font-size:12px;margin-right:6px">
       <option value="cold_outreach">Cold Outreach</option>
       <option value="recruiter_outreach">Recruiter</option>
+      <option value="referral_outreach">Referral Outreach</option>
       <option value="followup">Follow-up</option>
     </select>`;
+        const referralInput = `<input id="panel-referred-by" type="text" placeholder="Referred by" style="display:none;height:30px;padding:0 8px;border:1px solid var(--border);border-radius:6px;font-size:12px;margin-right:6px;min-width:150px">`;
         if (!emails?.length) {
-          eSect.innerHTML = `<h4>Emails</h4><p style="font-size:13px;color:var(--muted);margin-bottom:10px">No emails drafted. Click 'Draft email' on a job card.</p>${tmplSel}<button class="btn-accent" id="panel-draft-btn" style="height:30px;font-size:12px">Draft Email</button>`;
+          eSect.innerHTML = `<h4>Emails</h4><p style="font-size:13px;color:var(--muted);margin-bottom:10px">No emails drafted. Click 'Draft email' on a job card.</p>${tmplSel}${referralInput}<button class="btn-accent" id="panel-draft-btn" style="height:30px;font-size:12px">Draft Email</button>`;
         } else {
           eSect.innerHTML = `<h4>Emails</h4>${emails.map(e => `
         <div style="margin-bottom:8px;padding:10px;border:1px solid var(--border);border-radius:6px;font-size:12px">
           <div style="font-weight:500;margin-bottom:2px">${esc(e.subject)}</div>
           <div style="color:var(--muted)">${esc(e.template)} · ${statusBadge(e.status)}</div>
         </div>`).join('')}
-        <div style="margin-top:10px">${tmplSel}<button class="btn-accent" id="panel-draft-btn" style="height:30px;font-size:12px">Draft New</button></div>`;
+        <div style="margin-top:10px">${tmplSel}${referralInput}<button class="btn-accent" id="panel-draft-btn" style="height:30px;font-size:12px">Draft New</button></div>`;
         }
+        const tmplEl = document.getElementById('panel-tmpl');
+        const referredByEl = document.getElementById('panel-referred-by');
+        const syncReferralInput = () => {
+          if (referredByEl) referredByEl.style.display = tmplEl?.value === 'referral_outreach' ? 'inline-block' : 'none';
+        };
+        tmplEl?.addEventListener('change', syncReferralInput);
+        syncReferralInput();
         document.getElementById('panel-draft-btn')?.addEventListener('click', async () => {
-          const tmpl = document.getElementById('panel-tmpl')?.value || 'cold_outreach';
+          const tmpl = tmplEl?.value || 'cold_outreach';
+          const payload = { job_id: job.id, template: tmpl };
+          if (tmpl === 'referral_outreach' && referredByEl?.value.trim()) {
+            payload.referred_by = referredByEl.value.trim();
+          }
           toast('Generating…', 'info');
-          const r = await apiFetch('/workflow/apply', { method: 'POST', body: { job_id: job.id, template: tmpl } });
+          const r = await apiFetch('/workflow/apply', { method: 'POST', body: payload });
           if (r) { toast('Draft created!', 'success'); fetchPanelData(job); }
         });
       }

--- a/gateway/main.py
+++ b/gateway/main.py
@@ -190,7 +190,8 @@ async def proxy_generate(request: Request):
 
 class WorkflowRequest(BaseModel):
     job_id:   UUID
-    template: Literal["cold_outreach", "recruiter_outreach", "followup"] = "cold_outreach"
+    template: Literal["cold_outreach", "recruiter_outreach", "referral_outreach", "followup"] = "cold_outreach"
+    referred_by: Optional[str] = None
     roles:    list[str] = ["Engineering Manager", "Recruiter"]
 
 
@@ -237,6 +238,7 @@ async def workflow_apply(body: WorkflowRequest):
             job_id=body.job_id,
             contact_id=contact_id,
             template=body.template,
+            referred_by=body.referred_by,
         )
     except Exception as exc:
         logger.warning("Email generation failed: %s", exc)

--- a/gateway/proxy.py
+++ b/gateway/proxy.py
@@ -147,6 +147,7 @@ async def generate_email(
     job_id: UUID,
     contact_id: Optional[UUID],
     template: str,
+    referred_by: Optional[str] = None,
 ) -> Dict[str, Any]:
     client = get_client()
     payload: Dict[str, Any] = {
@@ -155,6 +156,8 @@ async def generate_email(
     }
     if contact_id:
         payload["contact_id"] = str(contact_id)
+    if referred_by:
+        payload["referred_by"] = referred_by
 
     resp = await client.post(
         f"{EMAIL_GEN_URL}/generate",

--- a/tests/unit/test_generator.py
+++ b/tests/unit/test_generator.py
@@ -96,6 +96,7 @@ _DEFAULT_CTX = dict(
     contact_email=None,
     graduation_year="2025",
     availability=None,
+    referred_by="Priya Menon",
 )
 
 
@@ -157,6 +158,29 @@ class TestRecruiterOutreachTemplate:
         assert "{{" not in subject + body
 
 
+class TestReferralOutreachTemplate:
+    def test_subject_contains_role_and_company(self):
+        subject, _ = _render("referral_outreach", **_DEFAULT_CTX)
+        assert "Backend Engineer" in subject
+        assert "Razorpay" in subject
+
+    def test_opening_mentions_referrer(self):
+        _, body = _render("referral_outreach", **_DEFAULT_CTX)
+        assert "Priya Menon" in body
+
+    def test_body_contains_product_observation(self):
+        _, body = _render("referral_outreach", **_DEFAULT_CTX)
+        assert "5M txns/day" in body
+
+    def test_no_jinja_artifacts(self):
+        subject, body = _render("referral_outreach", **_DEFAULT_CTX)
+        assert "{{" not in subject + body
+
+    def test_falls_back_to_mutual_connection_when_no_referrer(self):
+        _, body = _render("referral_outreach", **{**_DEFAULT_CTX, "referred_by": None})
+        assert "mutual connection" in body.lower()
+
+
 class TestFollowupTemplate:
     def test_body_non_empty(self):
         ctx = {**_DEFAULT_CTX, "product_observation": ""}
@@ -176,4 +200,5 @@ def test_valid_templates_set_unchanged():
     """Guard against accidental removals from the template registry."""
     assert "cold_outreach" in VALID_TEMPLATES
     assert "recruiter_outreach" in VALID_TEMPLATES
+    assert "referral_outreach" in VALID_TEMPLATES
     assert "followup" in VALID_TEMPLATES


### PR DESCRIPTION
Closes #14

## Changes

- Added a new `referral_outreach.j2` email template.
- Added support for the optional `referred_by` context field.
- Registered `referral_outreach` in the email generator template registry.
- Updated the email generation API and gateway workflow to accept and forward `referred_by`.
- Added `Referral Outreach` to the dashboard template selector.
- Added a `Referred by` field that appears when the referral template is selected.
- Added unit test coverage for the referral template.
- Fixed existing templates so missing contact names render as `Hi there` instead of `Hi None`.

## Testing

- Ran targeted email generator tests: `31 passed`
- Verified `referral_outreach.j2` renders the mutual connection naturally in the opening line.
- Verified gateway workflow accepts `template: referral_outreach` and forwards `referred_by`.
- Verified dashboard selector includes `Referral Outreach` and shows the `Referred by` input.
![Uploading referral-outreach-dashboard.png…]()
