### PR TITLE
feature: add CSV export button to dashboard

### DIFF
--- a/gateway/dashboard.html
+++ b/gateway/dashboard.html
@@ -873,6 +873,7 @@
           <option value="all">All stacks</option>
         </select>
         <button class="btn-outline" id="btn-refresh-jobs">Refresh</button>
+        <button class="btn-outline" id="btn-export-jobs">Export CSV</button>
       </div>
       <div id="jobs-grid" class="card-grid"></div>
     </section>
@@ -1481,6 +1482,30 @@
       else if (tab === 'stats') loadStats();
     }
 
+    function exportJobsCSV() {
+      const params = new URLSearchParams();
+
+      if (state.filters.search.trim()) {
+        params.set('search', state.filters.search.trim());
+      }
+
+      if (state.filters.status !== 'all') {
+        params.set('status', state.filters.status);
+      }
+
+      if (state.filters.stack !== 'all') {
+        params.set('stack', state.filters.stack);
+      }
+
+      params.set('format', 'csv');
+
+      const exportUrl = API(`/jobs/export?${params.toString()}`);
+
+      window.open(exportUrl, '_blank');
+
+      toast('Preparing CSV export...', 'info');
+    }
+
     // ===========================================================================
     // === EVENT WIRING ===
     // ===========================================================================
@@ -1504,6 +1529,7 @@
       renderJobs();
     });
     document.getElementById('btn-refresh-jobs').addEventListener('click', () => loadJobs(true));
+    document.getElementById('btn-export-jobs').addEventListener('click', exportJobsCSV);
     document.getElementById('btn-refresh-contacts').addEventListener('click', () => {
       state.contacts = {};
       loadContacts(true);


### PR DESCRIPTION
## Summary

Added a lightweight “Export CSV” button to the Jobs dashboard that constructs export requests using the currently active dashboard filters.

## Changes

* Added Export CSV button beside Jobs controls
* Preserved active search/status/stack filters during export
* Reused existing API helper and dashboard state
* Kept implementation dependency-free and compatible with the existing vanilla JS dashboard

## Testing

Verified:

* button renders correctly in dashboard UI
* export URL preserves active filters
* requests correctly reach `/api/jobs/export`

## Current Backend Limitation

While testing, the upstream export endpoint currently resolves against the dynamic `/jobs/{job_id}` route and returns a UUID parsing error.

The frontend integration itself is functional and correctly generates export requests, but the backend export route behavior still appears to be pending/stabilizing upstream.

## Screenshots

Included:

* dashboard integration
  
<img width="1907" height="877" alt="image" src="https://github.com/user-attachments/assets/e19df39b-3ca6-4813-b410-6d381d9e8cd6" />

* filter preservation behavior
<img width="1908" height="870" alt="image" src="https://github.com/user-attachments/assets/429738cd-bcad-431f-bcbb-f678190ab6eb" />


* current export endpoint failure response
<img width="812" height="550" alt="image" src="https://github.com/user-attachments/assets/da19a634-6616-4865-9979-b7b81fee5847" />
