### PR TITLE
Feat/internshala fulltime scraper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,20 @@
 /.env
+
+# Python bytecode and caches
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# Local Python environments
+.venv/
+venv/
+
+# Test and tooling caches
+.pytest_cache/
+.coverage
+coverage.xml
+
+# Local scratch / temporary files
+change.txt
+/__pycache__/

--- a/crawler-service/requirements.txt
+++ b/crawler-service/requirements.txt
@@ -1,5 +1,6 @@
 scrapy==2.11.1
 scrapy-playwright==0.0.34
+Twisted==22.10.0
 playwright==1.43.0
 httpx==0.27.0
 redis==5.0.4

--- a/scraper-service/Dockerfile
+++ b/scraper-service/Dockerfile
@@ -23,11 +23,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
+# Keep browser binaries in a shared location accessible to the runtime user.
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
 # Copy pre-built packages from builder
 COPY --from=builder /install /usr/local
 
 # Install Playwright browser binaries (chromium only, ~170 MB)
-RUN playwright install chromium
+RUN mkdir -p /ms-playwright && playwright install chromium
 
 # Copy source
 COPY . .

--- a/scraper-service/README.md
+++ b/scraper-service/README.md
@@ -21,7 +21,7 @@ scraper-service/
 │   ├── base.py              # PlatformScraper ABC
 │   ├── naukri.py            # httpx + BeautifulSoup (3 pages)
 │   ├── linkedin.py          # Playwright headless (public-only)
-│   └── internshala.py       # httpx + BeautifulSoup (2 pages)
+│   └── internshala.py       # httpx + BeautifulSoup (full-time jobs pages)
 ├── requirements.txt
 ├── Dockerfile
 └── README.md
@@ -151,19 +151,27 @@ URL pattern: `https://www.linkedin.com/jobs/search/?keywords={role}&location=Ind
 
 ### Internshala (`scrapers/internshala.py`)
 
-> Mostly server-rendered; httpx works well.  CAPTCHA appears after excessive requests.  
+> Mostly server-rendered; httpx works well. CAPTCHA appears after excessive requests.  
 > Keep `SCRAPER_DELAY_SECONDS ≥ 2`.
 
 | Selector constant | Target element |
 |---|---|
 | `card_sel` | `div.individual_internship` — one posting |
-| `title_sel` | `h3.job-internship-name a` / `div.profile h3 a` — title anchor |
-| `company_sel` | `h4.company-name a` / `div.company_name a` — company |
-| `loc_sel` | `a.location_link` — city |
-| `skills_sel` | `div.round_tabs_container span.round_tabs` — skill badges |
-| `stipend_sel` | `div.stipend_container span.stipend` — stipend/salary (mapped to `product` field) |
+| `title_sel` | `h2.job-internship-name a` / `h3.job-internship-name a` / `div.profile h3 a` / `a.job-title-href` — title anchor |
+| `company_sel` | `h4.company-name a` / `div.company_name a` / `p.company-name` / `div.company_and_premium p.company-name` — company |
+| `loc_sel` | `a.location_link` / `p.locations span a` / `p.locations span` / `div.internship_other_details_container span a` — city |
+| `skills_sel` | `div.job_skills div.job_skill` / `div.round_tabs_container span.round_tabs` / `div#skills_section span.skill` — skill badges |
+| `stipend_sel` | `div.detail-row-1 div.row-1-item span.desktop` / `div.stipend_container span.stipend` / `span.stipend` — stipend/salary (mapped to `product` field) |
 
-URL pattern: `https://internshala.com/jobs/keywords-{role-slug}/` (page 2: `?page=2`)
+URL pattern:
+
+- page 1: `https://internshala.com/jobs/{role-slug}-jobs/`
+- page 2+: `https://internshala.com/jobs/{role-slug}-jobs/page-N/`
+
+Other Internshala notes:
+
+- Posted dates are normalized to UTC ISO-8601 when the card contains relative labels like `today`, `yesterday`, or `2 days ago`.
+- Pagination stops early when a page has no cards, when Internshala returns an HTTP error, or when the final redirected URL repeats a previously seen page.
 
 ---
 

--- a/scraper-service/scrapers/internshala.py
+++ b/scraper-service/scrapers/internshala.py
@@ -2,7 +2,7 @@
 scrapers/internshala.py — Internshala job scraper using httpx + BeautifulSoup.
 
 Target URL pattern:
-    https://internshala.com/jobs/keywords-{role-slug}/
+    https://internshala.com/jobs/{role-slug}-jobs/
 
 Selector notes (last verified March 2026):
 ──────────────────────────────────────────────────────────────────────────────
@@ -23,12 +23,10 @@ Selector notes (last verified March 2026):
 ──────────────────────────────────────────────────────────────────────────────
 
 Pagination:
-  Internshala lists 12–15 jobs per page.  We fetch up to 2 pages
-  (there is no explicit page-number URL param — Internshala uses an
-  AJAX-based infinite scroll for logged-in users, but the first two
-  pages are accessible via:
-    page 1: /jobs/keywords-{slug}/
-    page 2: /jobs/keywords-{slug}/?page=2
+  Internshala lists 12–15 jobs per page. We fetch a small number of
+  server-rendered search pages and stop early when no cards are found:
+    page 1: /jobs/{slug}-jobs/
+        page 2: /jobs/{slug}-jobs/page-2/
 
 Rate-limiting notes:
   - Internshala does not aggressively block scrapers but does impose
@@ -43,6 +41,7 @@ import logging
 import os
 import random
 import re
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import httpx
@@ -53,7 +52,7 @@ from .base import PlatformScraper
 logger = logging.getLogger(__name__)
 
 BASE_URL  = "https://internshala.com"
-MAX_PAGES = 2
+MAX_PAGES = int(os.environ.get("INTERNSHALA_MAX_PAGES", 3))
 
 _HEADERS = {
     "User-Agent": (
@@ -70,6 +69,74 @@ def _role_to_slug(role: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", role.lower()).strip("-")
 
 
+def _build_page_url(role_slug: str, page: int) -> str:
+    base_url = f"{BASE_URL}/jobs/{role_slug}-jobs/"
+    if page == 1:
+        return base_url
+    return f"{base_url}/page-{page}"
+
+
+def _normalise_posted_at(raw_text: str | None) -> str | None:
+    """Convert relative labels like '2 days ago' into ISO-8601 UTC strings."""
+    if not raw_text:
+        return None
+
+    text = raw_text.strip().lower()
+    now = datetime.now(timezone.utc)
+
+    if text in {"today", "just now"}:
+        return now.isoformat()
+    if text == "yesterday":
+        return (now - timedelta(days=1)).isoformat()
+
+    m = re.search(
+        r"(\d+)\s+(minute|minutes|hour|hours|day|days|week|weeks|month|months)\s+ago",
+        text,
+    )
+    if not m:
+        return None
+
+    qty = int(m.group(1))
+    unit = m.group(2)
+    if unit.startswith("minute"):
+        dt = now - timedelta(minutes=qty)
+    elif unit.startswith("hour"):
+        dt = now - timedelta(hours=qty)
+    elif unit.startswith("day"):
+        dt = now - timedelta(days=qty)
+    elif unit.startswith("week"):
+        dt = now - timedelta(weeks=qty)
+    else:
+        dt = now - timedelta(days=qty * 30)
+    return dt.isoformat()
+
+
+def _extract_posted_at(card: Any) -> str | None:
+    posted_sel = (
+        "div.status-info span, "
+        "div.posted_by_container div.status-inactive span, "
+        "div.posted_recently, "
+        "div.desktop-text"
+    )
+
+    posted_el = card.select_one(posted_sel)
+    if posted_el:
+        posted_at = _normalise_posted_at(posted_el.get_text(" ", strip=True))
+        if posted_at:
+            return posted_at
+
+    # Fallback: scan the full card text for relative-time phrases.
+    card_text = card.get_text(" ", strip=True).lower()
+    match = re.search(
+        r"\b(just now|today|yesterday|\d+\s+"
+        r"(?:minute|minutes|hour|hours|day|days|week|weeks|month|months)\s+ago)\b",
+        card_text,
+    )
+    if not match:
+        return None
+    return _normalise_posted_at(match.group(1))
+
+
 def _parse_cards(soup: BeautifulSoup, role: str) -> list[dict[str, Any]]:
     """
     Extract job postings from one results page.
@@ -84,11 +151,11 @@ def _parse_cards(soup: BeautifulSoup, role: str) -> list[dict[str, Any]]:
       url_attr     : attribute on the title anchor holding the relative URL
     """
     card_sel    = "div.individual_internship"
-    title_sel   = "h3.job-internship-name a, div.profile h3 a"
-    company_sel = "h4.company-name a, div.company_name a, p.company-name"
-    loc_sel     = "a.location_link, div.internship_other_details_container span a"
-    skills_sel  = "div.round_tabs_container span.round_tabs, div#skills_section span.skill"
-    stipend_sel = "div.stipend_container span.stipend, span.stipend"
+    title_sel   = "h2.job-internship-name a, h3.job-internship-name a, div.profile h3 a, a.job-title-href"
+    company_sel = "h4.company-name a, div.company_name a, p.company-name, div.company_and_premium p.company-name"
+    loc_sel     = "a.location_link, p.locations span a, p.locations span, div.internship_other_details_container span a"
+    skills_sel  = "div.job_skills div.job_skill, div.round_tabs_container span.round_tabs, div#skills_section span.skill"
+    stipend_sel = "div.detail-row-1 div.row-1-item span.desktop, div.stipend_container span.stipend, span.stipend"
     url_attr    = "href"
 
     jobs: list[dict[str, Any]] = []
@@ -100,7 +167,7 @@ def _parse_cards(soup: BeautifulSoup, role: str) -> list[dict[str, Any]]:
                 continue
 
             title   = title_el.get_text(strip=True)
-            raw_url = title_el.get(url_attr, "")
+            raw_url = str(title_el.get(url_attr, "") or card.get("data-href", "") or "")
             job_url = raw_url if raw_url.startswith("http") else BASE_URL + raw_url
 
             company_el = card.select_one(company_sel)
@@ -114,6 +181,8 @@ def _parse_cards(soup: BeautifulSoup, role: str) -> list[dict[str, Any]]:
             stipend_el = card.select_one(stipend_sel)
             product    = stipend_el.get_text(strip=True) if stipend_el else None
 
+            posted_at = _extract_posted_at(card)
+
             if not company:
                 continue
 
@@ -126,7 +195,7 @@ def _parse_cards(soup: BeautifulSoup, role: str) -> list[dict[str, Any]]:
                     "stack":     skills,
                     "product":   product,      # reuse product field for stipend info
                     "location":  location,
-                    "posted_at": None,
+                    "posted_at": posted_at,
                 }
             )
         except Exception as exc:
@@ -145,6 +214,7 @@ class IntershalaScraper(PlatformScraper):
     async def scrape(self, role: str, stack: list[str]) -> list[dict[str, Any]]:
         slug = _role_to_slug(role)
         all_jobs: list[dict[str, Any]] = []
+        seen_final_urls: set[str] = set()
 
         async with httpx.AsyncClient(
             headers=_HEADERS,
@@ -152,10 +222,7 @@ class IntershalaScraper(PlatformScraper):
             timeout=20,
         ) as client:
             for page in range(1, MAX_PAGES + 1):
-                if page == 1:
-                    url = f"{BASE_URL}/jobs/keywords-{slug}/"
-                else:
-                    url = f"{BASE_URL}/jobs/keywords-{slug}/?page={page}"
+                url = _build_page_url(slug, page)
 
                 logger.info("[Internshala] Fetching page %d: %s", page, url)
                 try:
@@ -171,6 +238,16 @@ class IntershalaScraper(PlatformScraper):
                     logger.error("[Internshala] Request error page %d: %s", page, exc)
                     break
 
+                final_url = str(resp.url)
+                if final_url in seen_final_urls:
+                    logger.info(
+                        "[Internshala] Page %d redirected to an already seen URL (%s) — stopping pagination.",
+                        page,
+                        final_url,
+                    )
+                    break
+                seen_final_urls.add(final_url)
+
                 soup  = BeautifulSoup(resp.text, "html.parser")
                 cards = _parse_cards(soup, role)
                 logger.info("[Internshala] Page %d → %d jobs", page, len(cards))
@@ -180,8 +257,8 @@ class IntershalaScraper(PlatformScraper):
                     break
 
                 if page < MAX_PAGES:
-                    delay = self._delay + random.uniform(0, 1)
-                    await asyncio.sleep(max(delay, 2.0))
+                    delay = self._delay + random.uniform(0.5, 1.5)
+                    await asyncio.sleep(max(delay, 2.5))
 
         logger.info(
             "[Internshala] Total scraped: %d jobs for role '%s'", len(all_jobs), role


### PR DESCRIPTION
Closes #6

## What Changed
- Updated Internshala URL construction for full-time jobs.
- Added resilient fallback selectors for title, company, location, skills, and stipend extraction.
- Added posted date extraction with relative-time normalization to UTC ISO-8601 when possible.
- Added pagination safety guards: stop when no cards are found, stop on HTTP/request errors, and stop when redirected/canonical final URL repeats.
- Updated scraper-service README to reflect current Internshala behavior and selector coverage.

## Validation Done
- Ran scraper locally and verified end-to-end emission flow.
- Confirmed fetch and parse logs for Internshala pages.
- Confirmed redirect/canonical URL guard behavior during pagination.
- Confirmed emitted jobs were processed downstream.
- For demo validation only, LinkedIn and Naukri were temporarily excluded in scraper-service/main.py to run Internshala in isolation.

## Evidence

<h3>Demo</h3>

https://github.com/user-attachments/assets/3f8a9690-4924-4f33-a80f-3fba1e458965


<h3>Scrapper logs</h3>

<h4>Scrapper Startup </h4>
<img width="603" height="138" alt="Screenshot 2026-05-16 164639" src="https://github.com/user-attachments/assets/2593f3c4-5033-48be-9448-f055e642e74d" />

<br>
<h4> Trigger Scrapper for Backend roles</h4>

<img width="1202" height="239" alt="Screenshot 2026-05-16 164650" src="https://github.com/user-attachments/assets/547f4fa6-4731-43a5-b1eb-94210a9b1c07" />

<br>
<h4>Triggered Scrapper for Data analytics role</h4>

<img width="1164" height="306" alt="Screenshot 2026-05-16 164710" src="https://github.com/user-attachments/assets/cdf4a67b-b74a-4ea4-a7c0-d22917761d3e" />

## Selector Assumptions and Edge Cases
- Internshala markup may vary across listing cards; fallback selectors are intentional to reduce breakage.
- Missing required fields are skipped. Specifically: missing title element -> card skipped, missing company -> card skipped.
- Relative posted dates supported: just now, today, yesterday, and N minutes/hours/days/weeks/months ago.
- Unsupported date strings are left as null instead of forcing incorrect timestamps.
- Pagination also stops when a page resolves to a final URL already seen during this scrape (redirect/canonical URL guard).
