### PR TITLE
feat(dashboard): Kanban view with drag-and-drop and status sync 

### DIFF
--- a/gateway/dashboard.html
+++ b/gateway/dashboard.html
@@ -1,6 +1,6 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <!--
-  JobHunter Dashboard — single-file SPA served by FastAPI gateway at GET /
+  JobHunter Dashboard â€” single-file SPA served by FastAPI gateway at GET /
   =========================================================================
   API dependencies per view:
     Jobs:     GET /api/jobs, PATCH /api/jobs/{id}/status, POST /api/workflow/apply
@@ -831,6 +831,94 @@
       opacity: 0;
       transition: opacity .3s ease
     }
+      /* === KANBAN === */
+    #kanban-board {
+      display: none;
+      gap: 14px;
+      overflow-x: auto;
+      padding-bottom: 16px;
+      align-items: flex-start;
+    }
+    .kb-col {
+      min-width: 220px;
+      max-width: 240px;
+      flex-shrink: 0;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
+    }
+    .kb-col-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 14px;
+      border-bottom: 1px solid var(--border);
+      font-size: 13px;
+      font-weight: 500;
+    }
+    .kb-col-dot {
+      width: 8px; height: 8px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+    .kb-col-title { flex: 1; }
+    .kb-col-count {
+      font-size: 11px;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 99px;
+      padding: 1px 7px;
+      color: var(--muted);
+    }
+    .kb-cards {
+      padding: 10px;
+      min-height: 80px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      transition: background .15s;
+    }
+    .kb-cards.kb-drag-over {
+      background: var(--accent-low);
+    }
+    .kb-card {
+      cursor: grab;
+      position: relative;
+      user-select: none;
+    }
+    .kb-card.kb-dragging {
+      opacity: .4;
+      cursor: grabbing;
+    }
+    .kb-drop-placeholder {
+      height: 60px;
+      border: 2px dashed var(--accent);
+      border-radius: var(--radius);
+      background: var(--accent-low);
+    }
+    /* === VIEW TOGGLE === */
+    .view-toggle {
+      display: flex;
+      gap: 4px;
+      margin-left: 8px;
+    }
+    .view-toggle button {
+      height: 32px;
+      padding: 0 10px;
+      border-radius: 6px;
+      border: 1px solid var(--border);
+      background: var(--bg);
+      font-size: 13px;
+      color: var(--muted);
+      cursor: pointer;
+      transition: var(--trans);
+    }
+    .view-toggle button.active-view {
+      background: var(--accent);
+      color: #fff;
+      border-color: var(--accent);
+    }
   </style>
 </head>
 
@@ -847,12 +935,12 @@
         <button class="nav-tab" data-tab="stats">Stats</button>
       </div>
     </div>
-    <button id="btn-scrape">▶ Trigger Scrape</button>
+    <button id="btn-scrape">â–¶ Trigger Scrape</button>
   </nav>
 
   <!-- OFFLINE BANNER -->
   <div id="offline-banner">
-    <span>⚠ Cannot reach backend — is the gateway running?</span>
+    <span>âš  Cannot reach backend â€” is the gateway running?</span>
     <button class="btn-outline" style="height:26px;font-size:12px" id="btn-dismiss-banner">Dismiss</button>
   </div>
 
@@ -862,7 +950,7 @@
     <!-- JOBS TAB -->
     <section id="tab-jobs" class="tab-view active">
       <div class="filter-bar">
-        <input type="text" id="job-search" placeholder="Search company or role…" />
+        <input type="text" id="job-search" placeholder="Search company or roleâ€¦" />
         <select id="job-status-filter">
           <option value="all">All statuses</option>
           <option value="new">New</option>
@@ -873,14 +961,19 @@
           <option value="all">All stacks</option>
         </select>
         <button class="btn-outline" id="btn-refresh-jobs">Refresh</button>
+        <div class="view-toggle">
+          <button id="btn-view-grid" onclick="setView('grid')" title="Grid view">⊞ Grid</button>
+          <button id="btn-view-kanban" onclick="setView('kanban')" title="Kanban view">☰ Kanban</button>
+        </div>
       </div>
       <div id="jobs-grid" class="card-grid"></div>
+      <div id="kanban-board"></div>
     </section>
 
     <!-- CONTACTS TAB -->
     <section id="tab-contacts" class="tab-view">
       <div class="filter-bar">
-        <input type="text" id="contact-search" placeholder="Filter by company…" />
+        <input type="text" id="contact-search" placeholder="Filter by companyâ€¦" />
         <button class="btn-outline" id="btn-refresh-contacts">Refresh</button>
       </div>
       <div id="contacts-table-wrap" class="table-wrap">
@@ -924,22 +1017,22 @@
       <div class="metric-grid">
         <div class="metric-card">
           <div class="metric-label">Total Jobs</div>
-          <div class="metric-value" id="s-total">—</div>
+          <div class="metric-value" id="s-total">â€”</div>
           <div class="metric-trend" id="s-total-t"></div>
         </div>
         <div class="metric-card">
           <div class="metric-label">Applied</div>
-          <div class="metric-value" id="s-applied" style="color:var(--green)">—</div>
+          <div class="metric-value" id="s-applied" style="color:var(--green)">â€”</div>
           <div class="metric-trend" id="s-applied-t"></div>
         </div>
         <div class="metric-card">
           <div class="metric-label">Contacts Found</div>
-          <div class="metric-value" id="s-contacts" style="color:var(--accent)">—</div>
+          <div class="metric-value" id="s-contacts" style="color:var(--accent)">â€”</div>
           <div class="metric-trend" id="s-contacts-t"></div>
         </div>
         <div class="metric-card">
           <div class="metric-label">Emails Drafted</div>
-          <div class="metric-value" id="s-emails" style="color:var(--blue)">—</div>
+          <div class="metric-value" id="s-emails" style="color:var(--blue)">â€”</div>
           <div class="metric-trend" id="s-emails-t"></div>
         </div>
       </div>
@@ -950,7 +1043,7 @@
         <h4>Last Pipeline Run</h4>
         <div id="summary-content">
           <div class="empty">
-            <div class="empty-icon">🕐</div>
+            <div class="empty-icon">ðŸ•</div>
             <p>No run summary yet.</p>
           </div>
         </div>
@@ -967,7 +1060,7 @@
         <div id="panel-company" style="font-size:16px;font-weight:500"></div>
         <div id="panel-role" style="font-size:13px;color:var(--muted);margin-top:2px"></div>
       </div>
-      <button class="btn-close-x" id="panel-close">✕</button>
+      <button class="btn-close-x" id="panel-close">âœ•</button>
     </div>
     <div id="panel-content"></div>
   </aside>
@@ -977,7 +1070,7 @@
     <div class="modal">
       <div class="modal-header">
         <h3>Trigger Scrape</h3>
-        <button class="btn-close-x" id="modal-close">✕</button>
+        <button class="btn-close-x" id="modal-close">âœ•</button>
       </div>
       <div class="modal-body">
         <div class="field-group">
@@ -1084,7 +1177,7 @@
       return String(s ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
     }
     function relTime(iso) {
-      if (!iso) return '—';
+      if (!iso) return 'â€”';
       const diff = Date.now() - new Date(iso).getTime();
       const m = Math.floor(diff / 60000);
       if (m < 2) return 'just now';
@@ -1096,7 +1189,7 @@
       return new Date(iso).toLocaleDateString();
     }
     function fmtDate(iso) {
-      if (!iso) return '—';
+      if (!iso) return 'â€”';
       return new Date(iso).toLocaleDateString('en-IN', { day: '2-digit', month: 'short', year: 'numeric' });
     }
     function verifiedBadge(v) {
@@ -1120,7 +1213,7 @@
       document.getElementById('jobs-grid').innerHTML = `<div style="grid-column:1/-1;display:grid;grid-template-columns:repeat(3,1fr);gap:12px">${skelCards(6)}</div>`;
       const data = await apiFetch('/jobs?limit=200');
       if (!data) {
-        document.getElementById('jobs-grid').innerHTML = `<div class="empty" style="grid-column:1/-1"><div class="empty-icon">⚠</div><p>Failed to load jobs. <button class="btn-outline" onclick="loadJobs(true)">Retry</button></p></div>`;
+        document.getElementById('jobs-grid').innerHTML = `<div class="empty" style="grid-column:1/-1"><div class="empty-icon">âš </div><p>Failed to load jobs. <button class="btn-outline" onclick="loadJobs(true)">Retry</button></p></div>`;
         return;
       }
       state.jobs = Array.isArray(data) ? data : (data.jobs || []);
@@ -1155,15 +1248,15 @@
       const jobs = filteredJobs();
       const grid = document.getElementById('jobs-grid');
       if (!jobs.length) {
-        grid.innerHTML = `<div class="empty" style="grid-column:1/-1"><div class="empty-icon">🔍</div><p>No jobs found. Trigger a scrape to get started.</p></div>`;
+        grid.innerHTML = `<div class="empty" style="grid-column:1/-1"><div class="empty-icon">ðŸ”</div><p>No jobs found. Trigger a scrape to get started.</p></div>`;
         return;
       }
       grid.innerHTML = jobs.map(j => `
     <div class="job-card status-${esc(j.status || 'new')}" data-id="${esc(j.id)}">
       <div class="card-actions">
-        <button class="icon-btn" data-action="discover" data-id="${esc(j.id)}" title="Find contacts">👤</button>
-        <button class="icon-btn" data-action="draft" data-id="${esc(j.id)}" title="Draft email">✉</button>
-        <button class="icon-btn" data-action="apply" data-id="${esc(j.id)}" title="Mark applied">✓</button>
+        <button class="icon-btn" data-action="discover" data-id="${esc(j.id)}" title="Find contacts">ðŸ‘¤</button>
+        <button class="icon-btn" data-action="draft" data-id="${esc(j.id)}" title="Draft email">âœ‰</button>
+        <button class="icon-btn" data-action="apply" data-id="${esc(j.id)}" title="Mark applied">âœ“</button>
       </div>
       <div class="card-company">${esc(j.company)}</div>
       <div class="card-role">${esc(j.role)}</div>
@@ -1171,7 +1264,7 @@
         ${(j.stack || []).slice(0, 5).map(t => `<span class="tag">${esc(t)}</span>`).join('')}
       </div>
       <div class="card-footer">
-        <span class="tag tag-gray">${esc(j.source || '—')}</span>
+        <span class="tag tag-gray">${esc(j.source || 'â€”')}</span>
         <span>${relTime(j.posted_at)}</span>
       </div>
     </div>`).join('');
@@ -1180,7 +1273,7 @@
     async function discoverForJob(jobId) {
       const job = state.jobs.find(j => j.id === jobId);
       if (!job) return;
-      toast(`Discovering contacts for ${job.company}…`, 'info');
+      toast(`Discovering contacts for ${job.company}â€¦`, 'info');
       const r = await apiFetch('/workflow/apply', { method: 'POST', body: { job_id: jobId, template: 'cold_outreach' } });
       if (r) toast(`Workflow triggered for ${job.company}`, 'success');
     }
@@ -1188,12 +1281,12 @@
     async function draftForJob(jobId) {
       const job = state.jobs.find(j => j.id === jobId);
       if (!job) return;
-      toast('Generating draft email…', 'info');
+      toast('Generating draft emailâ€¦', 'info');
       const r = await apiFetch('/workflow/apply', { method: 'POST', body: { job_id: jobId, template: 'cold_outreach' } });
       if (r?.draft_email) {
         const { subject, body } = r.draft_email;
         openDetailPanel(jobId);
-        toast('Draft generated — see panel', 'success');
+        toast('Draft generated â€” see panel', 'success');
       }
     }
 
@@ -1224,11 +1317,11 @@
       document.getElementById('panel-content').innerHTML = `
     <div class="panel-section">
       <h4>Details</h4>
-      <div class="detail-field"><span class="detail-label">Source</span><span>${esc(job.source || '—')}</span></div>
+      <div class="detail-field"><span class="detail-label">Source</span><span>${esc(job.source || 'â€”')}</span></div>
       <div class="detail-field"><span class="detail-label">Status</span>${statusBadge(job.status)}</div>
-      <div class="detail-field"><span class="detail-label">Location</span><span>${esc(job.location || '—')}</span></div>
+      <div class="detail-field"><span class="detail-label">Location</span><span>${esc(job.location || 'â€”')}</span></div>
       <div class="detail-field"><span class="detail-label">Posted</span><span>${fmtDate(job.posted_at)}</span></div>
-      ${job.url ? `<div class="detail-field"><span class="detail-label">URL</span><a href="${esc(job.url)}" target="_blank" style="color:var(--accent)">Open ↗</a></div>` : ''}
+      ${job.url ? `<div class="detail-field"><span class="detail-label">URL</span><a href="${esc(job.url)}" target="_blank" style="color:var(--accent)">Open â†—</a></div>` : ''}
     </div>
     <div class="panel-section" id="panel-contacts-section">
       <h4>Contacts</h4><div class="skel skel-row"></div>
@@ -1251,8 +1344,8 @@
         } else {
           cSect.innerHTML = `<h4>Contacts</h4>${contacts.map(c => `
         <div style="margin-bottom:8px;font-size:13px">
-          <div style="font-weight:500">${esc(c.name || '—')}</div>
-          <div style="color:var(--muted)">${esc(c.email || '—')} · ${verifiedBadge(c.verified)}</div>
+          <div style="font-weight:500">${esc(c.name || 'â€”')}</div>
+          <div style="color:var(--muted)">${esc(c.email || 'â€”')} Â· ${verifiedBadge(c.verified)}</div>
         </div>`).join('')}`;
         }
       }
@@ -1270,13 +1363,13 @@
           eSect.innerHTML = `<h4>Emails</h4>${emails.map(e => `
         <div style="margin-bottom:8px;padding:10px;border:1px solid var(--border);border-radius:6px;font-size:12px">
           <div style="font-weight:500;margin-bottom:2px">${esc(e.subject)}</div>
-          <div style="color:var(--muted)">${esc(e.template)} · ${statusBadge(e.status)}</div>
+          <div style="color:var(--muted)">${esc(e.template)} Â· ${statusBadge(e.status)}</div>
         </div>`).join('')}
         <div style="margin-top:10px">${tmplSel}<button class="btn-accent" id="panel-draft-btn" style="height:30px;font-size:12px">Draft New</button></div>`;
         }
         document.getElementById('panel-draft-btn')?.addEventListener('click', async () => {
           const tmpl = document.getElementById('panel-tmpl')?.value || 'cold_outreach';
-          toast('Generating…', 'info');
+          toast('Generatingâ€¦', 'info');
           const r = await apiFetch('/workflow/apply', { method: 'POST', body: { job_id: job.id, template: tmpl } });
           if (r) { toast('Draft created!', 'success'); fetchPanelData(job); }
         });
@@ -1317,24 +1410,24 @@
       // Update sort icons
       document.querySelectorAll('#contacts-table th .sort-icon').forEach(el => el.textContent = '');
       const th = document.querySelector(`#contacts-table th[data-col="${state.contactSort.col}"] .sort-icon`);
-      if (th) th.textContent = state.contactSort.dir === 1 ? '↑' : '↓';
+      if (th) th.textContent = state.contactSort.dir === 1 ? 'â†‘' : 'â†“';
 
       if (!sorted.length) {
-        document.getElementById('contacts-body').innerHTML = `<tr><td colspan="6"><div class="empty"><div class="empty-icon">👤</div><p>No contacts discovered yet for this job.</p></div></td></tr>`;
+        document.getElementById('contacts-body').innerHTML = `<tr><td colspan="6"><div class="empty"><div class="empty-icon">ðŸ‘¤</div><p>No contacts discovered yet for this job.</p></div></td></tr>`;
         return;
       }
       document.getElementById('contacts-body').innerHTML = sorted.map((c, i) => `
     <tr class="contact-row" data-idx="${i}" style="cursor:pointer">
-      <td>${esc(c.name || '—')}</td>
-      <td>${esc(c.email || '—')}</td>
-      <td>${esc(c.role || '—')}</td>
+      <td>${esc(c.name || 'â€”')}</td>
+      <td>${esc(c.email || 'â€”')}</td>
+      <td>${esc(c.role || 'â€”')}</td>
       <td>${esc(c.company)}</td>
       <td>${verifiedBadge(c.verified)}</td>
       <td>${relTime(c.created_at)}</td>
     </tr>
     <tr id="cexpand-${i}" style="display:none">
       <td colspan="6" class="expand-row">
-        <strong>Source:</strong> ${esc(c.source || '—')} &nbsp;&nbsp;
+        <strong>Source:</strong> ${esc(c.source || 'â€”')} &nbsp;&nbsp;
         ${c.email ? `<button class="btn-outline" style="height:26px;font-size:12px" onclick="copyText('${esc(c.email)}')">Copy email</button>` : ''}
       </td>
     </tr>`).join('');
@@ -1362,20 +1455,20 @@
       allEmails.sort((a, b) => new Date(b.generated_at) - new Date(a.generated_at));
 
       if (!allEmails.length) {
-        document.getElementById('emails-body').innerHTML = `<tr><td colspan="6"><div class="empty"><div class="empty-icon">✉</div><p>No emails drafted. Click 'Draft email' on a job card.</p></div></td></tr>`;
+        document.getElementById('emails-body').innerHTML = `<tr><td colspan="6"><div class="empty"><div class="empty-icon">âœ‰</div><p>No emails drafted. Click 'Draft email' on a job card.</p></div></td></tr>`;
         return;
       }
 
       document.getElementById('emails-body').innerHTML = allEmails.map((e, i) => `
     <tr class="email-row" data-i="${i}">
-      <td><div style="font-weight:500">${esc(e._job?.company || '—')}</div><div style="font-size:12px;color:var(--muted)">${esc(e._job?.role || '—')}</div></td>
-      <td style="font-size:12px;color:var(--muted)">${esc(e.contact_id?.slice(0, 8) || '—')}…</td>
+      <td><div style="font-weight:500">${esc(e._job?.company || 'â€”')}</div><div style="font-size:12px;color:var(--muted)">${esc(e._job?.role || 'â€”')}</div></td>
+      <td style="font-size:12px;color:var(--muted)">${esc(e.contact_id?.slice(0, 8) || 'â€”')}â€¦</td>
       <td><span class="badge badge-gray">${esc(e.template)}</span></td>
       <td>${statusBadge(e.status)}</td>
       <td style="font-size:12px;color:var(--muted)">${relTime(e.generated_at)}</td>
       <td style="display:flex;gap:6px">
-        <button class="icon-btn email-view-btn" data-i="${i}" title="View">👁</button>
-        <button class="icon-btn email-send-btn" data-id="${esc(e.id)}" data-i="${i}" title="Send">📤</button>
+        <button class="icon-btn email-view-btn" data-i="${i}" title="View">ðŸ‘</button>
+        <button class="icon-btn email-send-btn" data-id="${esc(e.id)}" data-i="${i}" title="Send">ðŸ“¤</button>
       </td>
     </tr>
     <tr id="eexpand-${i}" style="display:none">
@@ -1421,10 +1514,10 @@
       const bySource = stats.by_source || {};
 
       const total = Object.values(byStatus).reduce((a, b) => a + b, 0);
-      document.getElementById('s-total').textContent = total || '—';
-      document.getElementById('s-applied').textContent = byStatus.applied ?? '—';
-      document.getElementById('s-contacts').textContent = sum.contacts_found ?? '—';
-      document.getElementById('s-emails').textContent = sum.emails_drafted ?? '—';
+      document.getElementById('s-total').textContent = total || 'â€”';
+      document.getElementById('s-applied').textContent = byStatus.applied ?? 'â€”';
+      document.getElementById('s-contacts').textContent = sum.contacts_found ?? 'â€”';
+      document.getElementById('s-emails').textContent = sum.emails_drafted ?? 'â€”';
 
       // Chart
       const labels = Object.keys(bySource);
@@ -1461,11 +1554,11 @@
       const errCount = (sum.errors || []).length;
       document.getElementById('summary-content').innerHTML = sum.run_at ? `
     <div class="summary-row"><span>Last run</span><span>${relTime(sum.run_at)}</span></div>
-    <div class="summary-row"><span>Jobs discovered</span><span>${sum.jobs_discovered ?? '—'}</span></div>
-    <div class="summary-row"><span>Contacts found</span><span>${sum.contacts_found ?? '—'}</span></div>
-    <div class="summary-row"><span>Emails drafted</span><span>${sum.emails_drafted ?? '—'}</span></div>
+    <div class="summary-row"><span>Jobs discovered</span><span>${sum.jobs_discovered ?? 'â€”'}</span></div>
+    <div class="summary-row"><span>Contacts found</span><span>${sum.contacts_found ?? 'â€”'}</span></div>
+    <div class="summary-row"><span>Emails drafted</span><span>${sum.emails_drafted ?? 'â€”'}</span></div>
     <div class="summary-row"><span>Errors</span><span>${errCount > 0 ? `<span class="badge badge-red">${errCount}</span>` : '<span class="badge badge-green">None</span>'}</span></div>
-  ` : `<div class="empty"><div class="empty-icon">🕐</div><p>No run summary yet. Scheduler hasn't completed a cycle.</p></div>`;
+  ` : `<div class="empty"><div class="empty-icon">ðŸ•</div><p>No run summary yet. Scheduler hasn't completed a cycle.</p></div>`;
     }
 
     // ===========================================================================
@@ -1586,7 +1679,7 @@
       btn.disabled = true;
       const r = await apiFetch('/scrape', { method: 'POST', body: { role, stack } });
       btn.disabled = false;
-      if (r !== null) toast('Scraping started — new jobs will appear in ~60 seconds', 'info', 6000);
+      if (r !== null) toast('Scraping started â€” new jobs will appear in ~60 seconds', 'info', 6000);
     });
 
     // Offline banner dismiss
@@ -1599,6 +1692,23 @@
       switchTab('jobs');
     })();
   </script>
+  <script src="/static/kanban.js"></script>
+  <script>
+    // Expose state so kanban.js can sync after drops
+    window._state = state;
+    // Hook into existing renderJobs so kanban auto-updates when jobs reload
+    const _origRenderJobs = renderJobs;
+    function renderJobs() {
+      _origRenderJobs();
+      const board = document.getElementById('kanban-board');
+      if (board && board.style.display !== 'none') renderKanban(state.jobs);
+    }
+    // Init toggle after page load
+    document.addEventListener('DOMContentLoaded', initViewToggle);
+  </script>
 </body>
 
 </html>
+
+
+

--- a/gateway/dashboard.html
+++ b/gateway/dashboard.html
@@ -1,6 +1,6 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <!--
-  JobHunter Dashboard â€” single-file SPA served by FastAPI gateway at GET /
+  JobHunter Dashboard — single-file SPA served by FastAPI gateway at GET /
   =========================================================================
   API dependencies per view:
     Jobs:     GET /api/jobs, PATCH /api/jobs/{id}/status, POST /api/workflow/apply
@@ -935,12 +935,12 @@
         <button class="nav-tab" data-tab="stats">Stats</button>
       </div>
     </div>
-    <button id="btn-scrape">â–¶ Trigger Scrape</button>
+    <button id="btn-scrape">▶ Trigger Scrape</button>
   </nav>
 
   <!-- OFFLINE BANNER -->
   <div id="offline-banner">
-    <span>âš  Cannot reach backend â€” is the gateway running?</span>
+    <span>⚠ Cannot reach backend — is the gateway running?</span>
     <button class="btn-outline" style="height:26px;font-size:12px" id="btn-dismiss-banner">Dismiss</button>
   </div>
 
@@ -950,7 +950,7 @@
     <!-- JOBS TAB -->
     <section id="tab-jobs" class="tab-view active">
       <div class="filter-bar">
-        <input type="text" id="job-search" placeholder="Search company or roleâ€¦" />
+        <input type="text" id="job-search" placeholder="Search company or role…" />
         <select id="job-status-filter">
           <option value="all">All statuses</option>
           <option value="new">New</option>
@@ -973,7 +973,7 @@
     <!-- CONTACTS TAB -->
     <section id="tab-contacts" class="tab-view">
       <div class="filter-bar">
-        <input type="text" id="contact-search" placeholder="Filter by companyâ€¦" />
+        <input type="text" id="contact-search" placeholder="Filter by company…" />
         <button class="btn-outline" id="btn-refresh-contacts">Refresh</button>
       </div>
       <div id="contacts-table-wrap" class="table-wrap">
@@ -1017,22 +1017,22 @@
       <div class="metric-grid">
         <div class="metric-card">
           <div class="metric-label">Total Jobs</div>
-          <div class="metric-value" id="s-total">â€”</div>
+          <div class="metric-value" id="s-total">—</div>
           <div class="metric-trend" id="s-total-t"></div>
         </div>
         <div class="metric-card">
           <div class="metric-label">Applied</div>
-          <div class="metric-value" id="s-applied" style="color:var(--green)">â€”</div>
+          <div class="metric-value" id="s-applied" style="color:var(--green)">—</div>
           <div class="metric-trend" id="s-applied-t"></div>
         </div>
         <div class="metric-card">
           <div class="metric-label">Contacts Found</div>
-          <div class="metric-value" id="s-contacts" style="color:var(--accent)">â€”</div>
+          <div class="metric-value" id="s-contacts" style="color:var(--accent)">—</div>
           <div class="metric-trend" id="s-contacts-t"></div>
         </div>
         <div class="metric-card">
           <div class="metric-label">Emails Drafted</div>
-          <div class="metric-value" id="s-emails" style="color:var(--blue)">â€”</div>
+          <div class="metric-value" id="s-emails" style="color:var(--blue)">—</div>
           <div class="metric-trend" id="s-emails-t"></div>
         </div>
       </div>
@@ -1043,7 +1043,7 @@
         <h4>Last Pipeline Run</h4>
         <div id="summary-content">
           <div class="empty">
-            <div class="empty-icon">ðŸ•</div>
+            <div class="empty-icon">🕐</div>
             <p>No run summary yet.</p>
           </div>
         </div>
@@ -1060,7 +1060,7 @@
         <div id="panel-company" style="font-size:16px;font-weight:500"></div>
         <div id="panel-role" style="font-size:13px;color:var(--muted);margin-top:2px"></div>
       </div>
-      <button class="btn-close-x" id="panel-close">âœ•</button>
+      <button class="btn-close-x" id="panel-close">✕</button>
     </div>
     <div id="panel-content"></div>
   </aside>
@@ -1070,7 +1070,7 @@
     <div class="modal">
       <div class="modal-header">
         <h3>Trigger Scrape</h3>
-        <button class="btn-close-x" id="modal-close">âœ•</button>
+        <button class="btn-close-x" id="modal-close">✕</button>
       </div>
       <div class="modal-body">
         <div class="field-group">
@@ -1177,7 +1177,7 @@
       return String(s ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
     }
     function relTime(iso) {
-      if (!iso) return 'â€”';
+      if (!iso) return '—';
       const diff = Date.now() - new Date(iso).getTime();
       const m = Math.floor(diff / 60000);
       if (m < 2) return 'just now';
@@ -1189,7 +1189,7 @@
       return new Date(iso).toLocaleDateString();
     }
     function fmtDate(iso) {
-      if (!iso) return 'â€”';
+      if (!iso) return '—';
       return new Date(iso).toLocaleDateString('en-IN', { day: '2-digit', month: 'short', year: 'numeric' });
     }
     function verifiedBadge(v) {
@@ -1213,7 +1213,7 @@
       document.getElementById('jobs-grid').innerHTML = `<div style="grid-column:1/-1;display:grid;grid-template-columns:repeat(3,1fr);gap:12px">${skelCards(6)}</div>`;
       const data = await apiFetch('/jobs?limit=200');
       if (!data) {
-        document.getElementById('jobs-grid').innerHTML = `<div class="empty" style="grid-column:1/-1"><div class="empty-icon">âš </div><p>Failed to load jobs. <button class="btn-outline" onclick="loadJobs(true)">Retry</button></p></div>`;
+        document.getElementById('jobs-grid').innerHTML = `<div class="empty" style="grid-column:1/-1"><div class="empty-icon">⚠</div><p>Failed to load jobs. <button class="btn-outline" onclick="loadJobs(true)">Retry</button></p></div>`;
         return;
       }
       state.jobs = Array.isArray(data) ? data : (data.jobs || []);
@@ -1248,15 +1248,15 @@
       const jobs = filteredJobs();
       const grid = document.getElementById('jobs-grid');
       if (!jobs.length) {
-        grid.innerHTML = `<div class="empty" style="grid-column:1/-1"><div class="empty-icon">ðŸ”</div><p>No jobs found. Trigger a scrape to get started.</p></div>`;
+        grid.innerHTML = `<div class="empty" style="grid-column:1/-1"><div class="empty-icon">🔍</div><p>No jobs found. Trigger a scrape to get started.</p></div>`;
         return;
       }
       grid.innerHTML = jobs.map(j => `
     <div class="job-card status-${esc(j.status || 'new')}" data-id="${esc(j.id)}">
       <div class="card-actions">
-        <button class="icon-btn" data-action="discover" data-id="${esc(j.id)}" title="Find contacts">ðŸ‘¤</button>
-        <button class="icon-btn" data-action="draft" data-id="${esc(j.id)}" title="Draft email">âœ‰</button>
-        <button class="icon-btn" data-action="apply" data-id="${esc(j.id)}" title="Mark applied">âœ“</button>
+        <button class="icon-btn" data-action="discover" data-id="${esc(j.id)}" title="Find contacts">👤</button>
+        <button class="icon-btn" data-action="draft" data-id="${esc(j.id)}" title="Draft email">✉</button>
+        <button class="icon-btn" data-action="apply" data-id="${esc(j.id)}" title="Mark applied">✓</button>
       </div>
       <div class="card-company">${esc(j.company)}</div>
       <div class="card-role">${esc(j.role)}</div>
@@ -1264,7 +1264,7 @@
         ${(j.stack || []).slice(0, 5).map(t => `<span class="tag">${esc(t)}</span>`).join('')}
       </div>
       <div class="card-footer">
-        <span class="tag tag-gray">${esc(j.source || 'â€”')}</span>
+        <span class="tag tag-gray">${esc(j.source || '—')}</span>
         <span>${relTime(j.posted_at)}</span>
       </div>
     </div>`).join('');
@@ -1273,7 +1273,7 @@
     async function discoverForJob(jobId) {
       const job = state.jobs.find(j => j.id === jobId);
       if (!job) return;
-      toast(`Discovering contacts for ${job.company}â€¦`, 'info');
+      toast(`Discovering contacts for ${job.company}…`, 'info');
       const r = await apiFetch('/workflow/apply', { method: 'POST', body: { job_id: jobId, template: 'cold_outreach' } });
       if (r) toast(`Workflow triggered for ${job.company}`, 'success');
     }
@@ -1281,12 +1281,12 @@
     async function draftForJob(jobId) {
       const job = state.jobs.find(j => j.id === jobId);
       if (!job) return;
-      toast('Generating draft emailâ€¦', 'info');
+      toast('Generating draft email…', 'info');
       const r = await apiFetch('/workflow/apply', { method: 'POST', body: { job_id: jobId, template: 'cold_outreach' } });
       if (r?.draft_email) {
         const { subject, body } = r.draft_email;
         openDetailPanel(jobId);
-        toast('Draft generated â€” see panel', 'success');
+        toast('Draft generated — see panel', 'success');
       }
     }
 
@@ -1317,11 +1317,11 @@
       document.getElementById('panel-content').innerHTML = `
     <div class="panel-section">
       <h4>Details</h4>
-      <div class="detail-field"><span class="detail-label">Source</span><span>${esc(job.source || 'â€”')}</span></div>
+      <div class="detail-field"><span class="detail-label">Source</span><span>${esc(job.source || '—')}</span></div>
       <div class="detail-field"><span class="detail-label">Status</span>${statusBadge(job.status)}</div>
-      <div class="detail-field"><span class="detail-label">Location</span><span>${esc(job.location || 'â€”')}</span></div>
+      <div class="detail-field"><span class="detail-label">Location</span><span>${esc(job.location || '—')}</span></div>
       <div class="detail-field"><span class="detail-label">Posted</span><span>${fmtDate(job.posted_at)}</span></div>
-      ${job.url ? `<div class="detail-field"><span class="detail-label">URL</span><a href="${esc(job.url)}" target="_blank" style="color:var(--accent)">Open â†—</a></div>` : ''}
+      ${job.url ? `<div class="detail-field"><span class="detail-label">URL</span><a href="${esc(job.url)}" target="_blank" style="color:var(--accent)">Open ↗</a></div>` : ''}
     </div>
     <div class="panel-section" id="panel-contacts-section">
       <h4>Contacts</h4><div class="skel skel-row"></div>
@@ -1344,8 +1344,8 @@
         } else {
           cSect.innerHTML = `<h4>Contacts</h4>${contacts.map(c => `
         <div style="margin-bottom:8px;font-size:13px">
-          <div style="font-weight:500">${esc(c.name || 'â€”')}</div>
-          <div style="color:var(--muted)">${esc(c.email || 'â€”')} Â· ${verifiedBadge(c.verified)}</div>
+          <div style="font-weight:500">${esc(c.name || '—')}</div>
+          <div style="color:var(--muted)">${esc(c.email || '—')} · ${verifiedBadge(c.verified)}</div>
         </div>`).join('')}`;
         }
       }
@@ -1363,13 +1363,13 @@
           eSect.innerHTML = `<h4>Emails</h4>${emails.map(e => `
         <div style="margin-bottom:8px;padding:10px;border:1px solid var(--border);border-radius:6px;font-size:12px">
           <div style="font-weight:500;margin-bottom:2px">${esc(e.subject)}</div>
-          <div style="color:var(--muted)">${esc(e.template)} Â· ${statusBadge(e.status)}</div>
+          <div style="color:var(--muted)">${esc(e.template)} · ${statusBadge(e.status)}</div>
         </div>`).join('')}
         <div style="margin-top:10px">${tmplSel}<button class="btn-accent" id="panel-draft-btn" style="height:30px;font-size:12px">Draft New</button></div>`;
         }
         document.getElementById('panel-draft-btn')?.addEventListener('click', async () => {
           const tmpl = document.getElementById('panel-tmpl')?.value || 'cold_outreach';
-          toast('Generatingâ€¦', 'info');
+          toast('Generating…', 'info');
           const r = await apiFetch('/workflow/apply', { method: 'POST', body: { job_id: job.id, template: tmpl } });
           if (r) { toast('Draft created!', 'success'); fetchPanelData(job); }
         });
@@ -1410,24 +1410,24 @@
       // Update sort icons
       document.querySelectorAll('#contacts-table th .sort-icon').forEach(el => el.textContent = '');
       const th = document.querySelector(`#contacts-table th[data-col="${state.contactSort.col}"] .sort-icon`);
-      if (th) th.textContent = state.contactSort.dir === 1 ? 'â†‘' : 'â†“';
+      if (th) th.textContent = state.contactSort.dir === 1 ? '↑' : '↓';
 
       if (!sorted.length) {
-        document.getElementById('contacts-body').innerHTML = `<tr><td colspan="6"><div class="empty"><div class="empty-icon">ðŸ‘¤</div><p>No contacts discovered yet for this job.</p></div></td></tr>`;
+        document.getElementById('contacts-body').innerHTML = `<tr><td colspan="6"><div class="empty"><div class="empty-icon">👤</div><p>No contacts discovered yet for this job.</p></div></td></tr>`;
         return;
       }
       document.getElementById('contacts-body').innerHTML = sorted.map((c, i) => `
     <tr class="contact-row" data-idx="${i}" style="cursor:pointer">
-      <td>${esc(c.name || 'â€”')}</td>
-      <td>${esc(c.email || 'â€”')}</td>
-      <td>${esc(c.role || 'â€”')}</td>
+      <td>${esc(c.name || '—')}</td>
+      <td>${esc(c.email || '—')}</td>
+      <td>${esc(c.role || '—')}</td>
       <td>${esc(c.company)}</td>
       <td>${verifiedBadge(c.verified)}</td>
       <td>${relTime(c.created_at)}</td>
     </tr>
     <tr id="cexpand-${i}" style="display:none">
       <td colspan="6" class="expand-row">
-        <strong>Source:</strong> ${esc(c.source || 'â€”')} &nbsp;&nbsp;
+        <strong>Source:</strong> ${esc(c.source || '—')} &nbsp;&nbsp;
         ${c.email ? `<button class="btn-outline" style="height:26px;font-size:12px" onclick="copyText('${esc(c.email)}')">Copy email</button>` : ''}
       </td>
     </tr>`).join('');
@@ -1455,20 +1455,20 @@
       allEmails.sort((a, b) => new Date(b.generated_at) - new Date(a.generated_at));
 
       if (!allEmails.length) {
-        document.getElementById('emails-body').innerHTML = `<tr><td colspan="6"><div class="empty"><div class="empty-icon">âœ‰</div><p>No emails drafted. Click 'Draft email' on a job card.</p></div></td></tr>`;
+        document.getElementById('emails-body').innerHTML = `<tr><td colspan="6"><div class="empty"><div class="empty-icon">✉</div><p>No emails drafted. Click 'Draft email' on a job card.</p></div></td></tr>`;
         return;
       }
 
       document.getElementById('emails-body').innerHTML = allEmails.map((e, i) => `
     <tr class="email-row" data-i="${i}">
-      <td><div style="font-weight:500">${esc(e._job?.company || 'â€”')}</div><div style="font-size:12px;color:var(--muted)">${esc(e._job?.role || 'â€”')}</div></td>
-      <td style="font-size:12px;color:var(--muted)">${esc(e.contact_id?.slice(0, 8) || 'â€”')}â€¦</td>
+      <td><div style="font-weight:500">${esc(e._job?.company || '—')}</div><div style="font-size:12px;color:var(--muted)">${esc(e._job?.role || '—')}</div></td>
+      <td style="font-size:12px;color:var(--muted)">${esc(e.contact_id?.slice(0, 8) || '—')}…</td>
       <td><span class="badge badge-gray">${esc(e.template)}</span></td>
       <td>${statusBadge(e.status)}</td>
       <td style="font-size:12px;color:var(--muted)">${relTime(e.generated_at)}</td>
       <td style="display:flex;gap:6px">
-        <button class="icon-btn email-view-btn" data-i="${i}" title="View">ðŸ‘</button>
-        <button class="icon-btn email-send-btn" data-id="${esc(e.id)}" data-i="${i}" title="Send">ðŸ“¤</button>
+        <button class="icon-btn email-view-btn" data-i="${i}" title="View">👁</button>
+        <button class="icon-btn email-send-btn" data-id="${esc(e.id)}" data-i="${i}" title="Send">📤</button>
       </td>
     </tr>
     <tr id="eexpand-${i}" style="display:none">
@@ -1514,10 +1514,10 @@
       const bySource = stats.by_source || {};
 
       const total = Object.values(byStatus).reduce((a, b) => a + b, 0);
-      document.getElementById('s-total').textContent = total || 'â€”';
-      document.getElementById('s-applied').textContent = byStatus.applied ?? 'â€”';
-      document.getElementById('s-contacts').textContent = sum.contacts_found ?? 'â€”';
-      document.getElementById('s-emails').textContent = sum.emails_drafted ?? 'â€”';
+      document.getElementById('s-total').textContent = total || '—';
+      document.getElementById('s-applied').textContent = byStatus.applied ?? '—';
+      document.getElementById('s-contacts').textContent = sum.contacts_found ?? '—';
+      document.getElementById('s-emails').textContent = sum.emails_drafted ?? '—';
 
       // Chart
       const labels = Object.keys(bySource);
@@ -1554,11 +1554,11 @@
       const errCount = (sum.errors || []).length;
       document.getElementById('summary-content').innerHTML = sum.run_at ? `
     <div class="summary-row"><span>Last run</span><span>${relTime(sum.run_at)}</span></div>
-    <div class="summary-row"><span>Jobs discovered</span><span>${sum.jobs_discovered ?? 'â€”'}</span></div>
-    <div class="summary-row"><span>Contacts found</span><span>${sum.contacts_found ?? 'â€”'}</span></div>
-    <div class="summary-row"><span>Emails drafted</span><span>${sum.emails_drafted ?? 'â€”'}</span></div>
+    <div class="summary-row"><span>Jobs discovered</span><span>${sum.jobs_discovered ?? '—'}</span></div>
+    <div class="summary-row"><span>Contacts found</span><span>${sum.contacts_found ?? '—'}</span></div>
+    <div class="summary-row"><span>Emails drafted</span><span>${sum.emails_drafted ?? '—'}</span></div>
     <div class="summary-row"><span>Errors</span><span>${errCount > 0 ? `<span class="badge badge-red">${errCount}</span>` : '<span class="badge badge-green">None</span>'}</span></div>
-  ` : `<div class="empty"><div class="empty-icon">ðŸ•</div><p>No run summary yet. Scheduler hasn't completed a cycle.</p></div>`;
+  ` : `<div class="empty"><div class="empty-icon">🕐</div><p>No run summary yet. Scheduler hasn't completed a cycle.</p></div>`;
     }
 
     // ===========================================================================
@@ -1679,7 +1679,7 @@
       btn.disabled = true;
       const r = await apiFetch('/scrape', { method: 'POST', body: { role, stack } });
       btn.disabled = false;
-      if (r !== null) toast('Scraping started â€” new jobs will appear in ~60 seconds', 'info', 6000);
+      if (r !== null) toast('Scraping started — new jobs will appear in ~60 seconds', 'info', 6000);
     });
 
     // Offline banner dismiss

--- a/gateway/main.py
+++ b/gateway/main.py
@@ -1,14 +1,14 @@
-"""
-main.py — FastAPI API Gateway for the Job Discovery System.
+﻿"""
+main.py â€” FastAPI API Gateway for the Job Discovery System.
 
 Routes:
-  /api/jobs/*         → aggregator:8000
-  /api/scrape         → scraper:8001
-  /api/contacts/*     → contact:8002
-  /api/emails/*       → email-gen:8003
+  /api/jobs/*         â†’ aggregator:8000
+  /api/scrape         â†’ scraper:8001
+  /api/contacts/*     â†’ contact:8002
+  /api/emails/*       â†’ email-gen:8003
 
 Composite endpoints (gateway-owned logic):
-  POST /api/workflow/apply   Orchestrates job → discovery → email draft
+  POST /api/workflow/apply   Orchestrates job â†’ discovery â†’ email draft
   GET  /api/health           Fans out to all four services
 
 Dashboard:
@@ -35,7 +35,7 @@ import proxy
 
 logging.basicConfig(
     level=logging.INFO,
-    format="%(asctime)s  %(levelname)-8s  %(name)s — %(message)s",
+    format="%(asctime)s  %(levelname)-8s  %(name)s â€” %(message)s",
 )
 logger = logging.getLogger(__name__)
 
@@ -44,7 +44,7 @@ SUMMARY_PATH   = Path(os.environ.get("SUMMARY_PATH", "/data/run_summary.json"))
 
 
 # ---------------------------------------------------------------------------
-# Lifespan — shared httpx client
+# Lifespan â€” shared httpx client
 # ---------------------------------------------------------------------------
 
 @asynccontextmanager
@@ -119,7 +119,7 @@ async def run_summary():
 
 
 # ---------------------------------------------------------------------------
-# Proxy routes — /api/jobs/*
+# Proxy routes â€” /api/jobs/*
 # ---------------------------------------------------------------------------
 
 @app.api_route("/api/jobs", methods=["GET", "POST"], tags=["proxy"])
@@ -138,7 +138,7 @@ async def proxy_stats(request: Request):
 
 
 # ---------------------------------------------------------------------------
-# Proxy routes — /api/scrape
+# Proxy routes â€” /api/scrape
 # ---------------------------------------------------------------------------
 
 @app.api_route("/api/scrape", methods=["GET", "POST"], tags=["proxy"])
@@ -147,7 +147,7 @@ async def proxy_scrape(request: Request):
 
 
 # ---------------------------------------------------------------------------
-# Proxy routes — /api/contacts/*
+# Proxy routes â€” /api/contacts/*
 # ---------------------------------------------------------------------------
 
 @app.api_route("/api/contacts", methods=["GET", "POST"], tags=["proxy"])
@@ -166,7 +166,7 @@ async def proxy_discover(request: Request):
 
 
 # ---------------------------------------------------------------------------
-# Proxy routes — /api/emails/*
+# Proxy routes â€” /api/emails/*
 # ---------------------------------------------------------------------------
 
 @app.api_route("/api/emails", methods=["GET"], tags=["proxy"])
@@ -185,7 +185,7 @@ async def proxy_generate(request: Request):
 
 
 # ---------------------------------------------------------------------------
-# Composite endpoint — POST /api/workflow/apply
+# Composite endpoint â€” POST /api/workflow/apply
 # ---------------------------------------------------------------------------
 
 class WorkflowRequest(BaseModel):
@@ -204,23 +204,23 @@ async def workflow_apply(body: WorkflowRequest):
       4. Generate a draft email for the first verified/unverified contact.
       5. Return job + contacts + draft email in a single response.
     """
-    # Step 1 — Job details
+    # Step 1 â€” Job details
     job = await proxy.get_job(body.job_id)
 
-    # Step 2 — Trigger discovery (runs in background on the contact service)
+    # Step 2 â€” Trigger discovery (runs in background on the contact service)
     await proxy.trigger_discovery(
         company=job["company"],
         job_id=body.job_id,
         roles=body.roles,
     )
 
-    # Step 3 — Wait for the background pipeline to populate contacts
+    # Step 3 â€” Wait for the background pipeline to populate contacts
     # (contact discovery is fire-and-background; the aggregator typically
     #  completes the DB-only part in <2 s when names are already known)
     await asyncio.sleep(3)
     contacts = await proxy.get_contacts_for_company(job["company"])
 
-    # Step 4 — Pick the best contact for email generation
+    # Step 4 â€” Pick the best contact for email generation
     contact_id: Optional[UUID] = None
     if contacts:
         # Prefer verified > unverified; ignore 'invalid'
@@ -231,7 +231,7 @@ async def workflow_apply(body: WorkflowRequest):
         if ordered:
             contact_id = UUID(ordered[0]["id"])
 
-    # Step 5 — Generate email draft
+    # Step 5 â€” Generate email draft
     try:
         email = await proxy.generate_email(
             job_id=body.job_id,
@@ -247,3 +247,5 @@ async def workflow_apply(body: WorkflowRequest):
         "contacts": contacts,
         "draft_email": email,
     }
+
+

--- a/gateway/main.py
+++ b/gateway/main.py
@@ -1,14 +1,14 @@
-﻿"""
-main.py â€” FastAPI API Gateway for the Job Discovery System.
+"""
+main.py — FastAPI API Gateway for the Job Discovery System.
 
 Routes:
-  /api/jobs/*         â†’ aggregator:8000
-  /api/scrape         â†’ scraper:8001
-  /api/contacts/*     â†’ contact:8002
-  /api/emails/*       â†’ email-gen:8003
+  /api/jobs/*         → aggregator:8000
+  /api/scrape         → scraper:8001
+  /api/contacts/*     → contact:8002
+  /api/emails/*       → email-gen:8003
 
 Composite endpoints (gateway-owned logic):
-  POST /api/workflow/apply   Orchestrates job â†’ discovery â†’ email draft
+  POST /api/workflow/apply   Orchestrates job → discovery → email draft
   GET  /api/health           Fans out to all four services
 
 Dashboard:
@@ -35,7 +35,7 @@ import proxy
 
 logging.basicConfig(
     level=logging.INFO,
-    format="%(asctime)s  %(levelname)-8s  %(name)s â€” %(message)s",
+    format="%(asctime)s  %(levelname)-8s  %(name)s — %(message)s",
 )
 logger = logging.getLogger(__name__)
 
@@ -44,7 +44,7 @@ SUMMARY_PATH   = Path(os.environ.get("SUMMARY_PATH", "/data/run_summary.json"))
 
 
 # ---------------------------------------------------------------------------
-# Lifespan â€” shared httpx client
+# Lifespan — shared httpx client
 # ---------------------------------------------------------------------------
 
 @asynccontextmanager
@@ -119,7 +119,7 @@ async def run_summary():
 
 
 # ---------------------------------------------------------------------------
-# Proxy routes â€” /api/jobs/*
+# Proxy routes — /api/jobs/*
 # ---------------------------------------------------------------------------
 
 @app.api_route("/api/jobs", methods=["GET", "POST"], tags=["proxy"])
@@ -138,7 +138,7 @@ async def proxy_stats(request: Request):
 
 
 # ---------------------------------------------------------------------------
-# Proxy routes â€” /api/scrape
+# Proxy routes — /api/scrape
 # ---------------------------------------------------------------------------
 
 @app.api_route("/api/scrape", methods=["GET", "POST"], tags=["proxy"])
@@ -147,7 +147,7 @@ async def proxy_scrape(request: Request):
 
 
 # ---------------------------------------------------------------------------
-# Proxy routes â€” /api/contacts/*
+# Proxy routes — /api/contacts/*
 # ---------------------------------------------------------------------------
 
 @app.api_route("/api/contacts", methods=["GET", "POST"], tags=["proxy"])
@@ -166,7 +166,7 @@ async def proxy_discover(request: Request):
 
 
 # ---------------------------------------------------------------------------
-# Proxy routes â€” /api/emails/*
+# Proxy routes — /api/emails/*
 # ---------------------------------------------------------------------------
 
 @app.api_route("/api/emails", methods=["GET"], tags=["proxy"])
@@ -185,7 +185,7 @@ async def proxy_generate(request: Request):
 
 
 # ---------------------------------------------------------------------------
-# Composite endpoint â€” POST /api/workflow/apply
+# Composite endpoint — POST /api/workflow/apply
 # ---------------------------------------------------------------------------
 
 class WorkflowRequest(BaseModel):
@@ -204,23 +204,23 @@ async def workflow_apply(body: WorkflowRequest):
       4. Generate a draft email for the first verified/unverified contact.
       5. Return job + contacts + draft email in a single response.
     """
-    # Step 1 â€” Job details
+    # Step 1 — Job details
     job = await proxy.get_job(body.job_id)
 
-    # Step 2 â€” Trigger discovery (runs in background on the contact service)
+    # Step 2 — Trigger discovery (runs in background on the contact service)
     await proxy.trigger_discovery(
         company=job["company"],
         job_id=body.job_id,
         roles=body.roles,
     )
 
-    # Step 3 â€” Wait for the background pipeline to populate contacts
+    # Step 3 — Wait for the background pipeline to populate contacts
     # (contact discovery is fire-and-background; the aggregator typically
     #  completes the DB-only part in <2 s when names are already known)
     await asyncio.sleep(3)
     contacts = await proxy.get_contacts_for_company(job["company"])
 
-    # Step 4 â€” Pick the best contact for email generation
+    # Step 4 — Pick the best contact for email generation
     contact_id: Optional[UUID] = None
     if contacts:
         # Prefer verified > unverified; ignore 'invalid'
@@ -231,7 +231,7 @@ async def workflow_apply(body: WorkflowRequest):
         if ordered:
             contact_id = UUID(ordered[0]["id"])
 
-    # Step 5 â€” Generate email draft
+    # Step 5 — Generate email draft
     try:
         email = await proxy.generate_email(
             job_id=body.job_id,

--- a/gateway/static/kanban.js
+++ b/gateway/static/kanban.js
@@ -1,0 +1,210 @@
+﻿/* kanban.js — Vanilla JS Kanban board for Arachnode dashboard
+   Columns: Discovered → Contacted → Applied → Interviewing → Offer / Rejected
+   - Drag-and-drop between columns (HTML5 drag API, no heavy libs)
+   - PATCH /api/jobs/{id}/status on drop with optimistic update + rollback
+   - Grid ↔ Kanban toggle persisted in localStorage
+*/
+
+const KANBAN_COLUMNS = [
+  { id: 'discovered',   label: 'Discovered',   color: '#6c47ff' },
+  { id: 'contacted',    label: 'Contacted',     color: '#3b82f6' },
+  { id: 'applied',      label: 'Applied',       color: '#10b981' },
+  { id: 'interviewing', label: 'Interviewing',  color: '#f59e0b' },
+  { id: 'offer',        label: 'Offer',         color: '#22c55e' },
+  { id: 'rejected',     label: 'Rejected',      color: '#ef4444' },
+];
+
+// Map existing statuses to kanban columns
+const STATUS_MAP = {
+  new:          'discovered',
+  discovered:   'discovered',
+  contacted:    'contacted',
+  applied:      'applied',
+  interviewing: 'interviewing',
+  offer:        'offer',
+  rejected:     'rejected',
+  ignored:      'rejected',
+};
+
+let _dragSrcId   = null;   // job id being dragged
+let _dragSrcCol  = null;   // original column id
+let _kanbanJobs  = [];     // local copy for optimistic updates
+
+// ── Render ──────────────────────────────────────────────────────────────────
+
+function renderKanban(jobs) {
+  _kanbanJobs = jobs.map(j => ({ ...j }));
+
+  const board = document.getElementById('kanban-board');
+  if (!board) return;
+
+  // Group jobs by column
+  const grouped = {};
+  KANBAN_COLUMNS.forEach(c => { grouped[c.id] = []; });
+  _kanbanJobs.forEach(j => {
+    const col = STATUS_MAP[j.status] || 'discovered';
+    grouped[col].push(j);
+  });
+
+  board.innerHTML = KANBAN_COLUMNS.map(col => `
+    <div class="kb-col" data-col="${col.id}">
+      <div class="kb-col-header">
+        <span class="kb-col-dot" style="background:${col.color}"></span>
+        <span class="kb-col-title">${col.label}</span>
+        <span class="kb-col-count">${grouped[col.id].length}</span>
+      </div>
+      <div class="kb-cards" data-col="${col.id}"
+           ondragover="kbDragOver(event)"
+           ondragleave="kbDragLeave(event)"
+           ondrop="kbDrop(event)">
+        ${grouped[col.id].map(j => kbCardHTML(j)).join('')}
+        <div class="kb-drop-placeholder" style="display:none"></div>
+      </div>
+    </div>
+  `).join('');
+}
+
+function kbCardHTML(j) {
+  const esc = s => String(s ?? '').replace(/[&<>"']/g, c =>
+    ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c]));
+  const tags = (j.stack || []).slice(0, 3).map(t =>
+    `<span class="tag">${esc(t)}</span>`).join('');
+  return `
+    <div class="kb-card job-card"
+         draggable="true"
+         data-id="${esc(j.id)}"
+         ondragstart="kbDragStart(event)"
+         ondragend="kbDragEnd(event)"
+         onclick="openDetailPanel('${esc(j.id)}')">
+      <div class="card-company">${esc(j.company)}</div>
+      <div class="card-role">${esc(j.role)}</div>
+      <div class="card-tags">${tags}</div>
+      <div class="card-footer">
+        <span class="tag tag-gray">${esc(j.source || '—')}</span>
+      </div>
+    </div>`;
+}
+
+// ── Drag handlers ────────────────────────────────────────────────────────────
+
+function kbDragStart(e) {
+  const card = e.currentTarget;
+  _dragSrcId  = card.dataset.id;
+  _dragSrcCol = card.closest('.kb-cards').dataset.col;
+  e.dataTransfer.effectAllowed = 'move';
+  e.dataTransfer.setData('text/plain', _dragSrcId);
+  setTimeout(() => card.classList.add('kb-dragging'), 0);
+}
+
+function kbDragEnd(e) {
+  e.currentTarget.classList.remove('kb-dragging');
+  document.querySelectorAll('.kb-cards').forEach(c => {
+    c.classList.remove('kb-drag-over');
+    const ph = c.querySelector('.kb-drop-placeholder');
+    if (ph) ph.style.display = 'none';
+  });
+}
+
+function kbDragOver(e) {
+  e.preventDefault();
+  e.dataTransfer.dropEffect = 'move';
+  const zone = e.currentTarget;
+  zone.classList.add('kb-drag-over');
+  const ph = zone.querySelector('.kb-drop-placeholder');
+  if (ph) ph.style.display = 'block';
+}
+
+function kbDragLeave(e) {
+  const zone = e.currentTarget;
+  if (!zone.contains(e.relatedTarget)) {
+    zone.classList.remove('kb-drag-over');
+    const ph = zone.querySelector('.kb-drop-placeholder');
+    if (ph) ph.style.display = 'none';
+  }
+}
+
+async function kbDrop(e) {
+  e.preventDefault();
+  const zone    = e.currentTarget;
+  const newCol  = zone.dataset.col;
+  zone.classList.remove('kb-drag-over');
+
+  if (!_dragSrcId || newCol === _dragSrcCol) return;
+
+  // Optimistic update — move card locally immediately
+  const jobIdx = _kanbanJobs.findIndex(j => j.id === _dragSrcId);
+  if (jobIdx === -1) return;
+  const prevStatus = _kanbanJobs[jobIdx].status;
+  _kanbanJobs[jobIdx].status = newCol;
+  renderKanban(_kanbanJobs);
+
+  // PATCH backend
+  try {
+    const res = await fetch(`/api/jobs/${_dragSrcId}/status`, {
+      method:  'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body:    JSON.stringify({ status: newCol }),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    // Sync back to main state.jobs array
+    const mainJob = (window._state?.jobs || []).find(j => j.id === _dragSrcId);
+    if (mainJob) mainJob.status = newCol;
+    showKbToast(`Moved to ${KANBAN_COLUMNS.find(c => c.id === newCol)?.label}`, 'success');
+  } catch (err) {
+    // Rollback on failure
+    _kanbanJobs[jobIdx].status = prevStatus;
+    renderKanban(_kanbanJobs);
+    showKbToast('Status update failed — reverted', 'error');
+  }
+}
+
+// ── Toast (reuses existing toast if available, else own) ─────────────────────
+
+function showKbToast(msg, type) {
+  if (typeof toast === 'function') { toast(msg, type); return; }
+  const el = document.createElement('div');
+  el.className = `toast ${type}`;
+  el.textContent = msg;
+  document.getElementById('toasts')?.appendChild(el);
+  setTimeout(() => { el.classList.add('fade-out'); setTimeout(() => el.remove(), 350); }, 3000);
+}
+
+// ── View toggle ──────────────────────────────────────────────────────────────
+
+function initViewToggle() {
+  const saved = localStorage.getItem('arachnode_view') || 'grid';
+  setView(saved, false);
+}
+
+function setView(view, save = true) {
+  const grid   = document.getElementById('jobs-grid');
+  const board  = document.getElementById('kanban-board');
+  const btnG   = document.getElementById('btn-view-grid');
+  const btnK   = document.getElementById('btn-view-kanban');
+
+  if (view === 'kanban') {
+    grid?.style  && (grid.style.display  = 'none');
+    board?.style && (board.style.display = 'flex');
+    btnG?.classList.remove('active-view');
+    btnK?.classList.add('active-view');
+    if (window._state?.jobs?.length) renderKanban(window._state.jobs);
+  } else {
+    grid?.style  && (grid.style.display  = '');
+    board?.style && (board.style.display = 'none');
+    btnG?.classList.add('active-view');
+    btnK?.classList.remove('active-view');
+    if (typeof renderJobs === 'function') renderJobs();
+  }
+
+  if (save) localStorage.setItem('arachnode_view', view);
+}
+
+// Expose globally so dashboard.html can call them
+window.kbDragStart  = kbDragStart;
+window.kbDragEnd    = kbDragEnd;
+window.kbDragOver   = kbDragOver;
+window.kbDragLeave  = kbDragLeave;
+window.kbDrop       = kbDrop;
+window.renderKanban = renderKanban;
+window.initViewToggle = initViewToggle;
+window.setView      = setView;


### PR DESCRIPTION
Hey @sharmavaibhav31 
**The Kanban view feature is implemented and ready for review**

**Here's what was added:**
The jobs view now has a Grid / Kanban toggle in the filter bar, with the 
selected view persisted in localStorage across page refreshes.
The Kanban board has six columns : Discovered, Contacted, Applied, 
Interviewing, Offer, and Rejected matching the existing status flow 
without any schema changes.

Cards are draggable between columns using the native HTML5 drag API with 
no additional libraries, keeping the implementation lightweight and aligned 
with the existing vanilla JS frontend. On drop, a PATCH /api/jobs/{id}/status 
request fires in the background. The card moves immediately (optimistic update) 
and reverts with an error toast if the API call fails.

The existing job card component is reused inside the Kanban so both views 
stay visually consistent.

**I'll be adding screenshots to the PR description shortly showing the drag/drop 
behavior, status sync, rollback handling, and Grid ↔ Kanban switching.**

Let me know if you'd like any changes in the meantime.