### PR TITLE
Fix/followup scheduling clean

### DIFF
--- a/scheduler/main.py
+++ b/scheduler/main.py
@@ -162,6 +162,16 @@ def build_scheduler() -> BackgroundScheduler:
         name="Weekly job digest email",
     )
 
+
+    # -- Job 4: Check for follow-ups every 24 hours --
+    scheduler.add_job(
+        func=lambda: _run(tasks.run_followup_cycle, "followup"),
+        trigger="interval",
+        hours=24,
+        id="followup",
+        name="Follow-up reminder drafting",
+        start_date=_offset_start(hours=12),
+    )
     return scheduler
 
 
@@ -178,7 +188,7 @@ def _offset_start(hours: int) -> datetime:
 def _maybe_manual_run() -> None:
     """
     If MANUAL_TASK env var is set, run that task immediately and exit.
-    Valid values: scrape | discover | draft | digest | all
+    Valid values: scrape | discover | draft | digest | followup | all
     """
     task_name = os.environ.get("MANUAL_TASK", "").strip().lower()
     if not task_name:
@@ -190,6 +200,7 @@ def _maybe_manual_run() -> None:
         "discover": tasks.run_discover_cycle,
         "draft":    tasks.run_draft_cycle,
         "digest":   tasks.run_digest_cycle,
+        "followup": tasks.run_followup_cycle,
     }
 
     if task_name == "all":
@@ -233,3 +244,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+

--- a/scheduler/tasks.py
+++ b/scheduler/tasks.py
@@ -361,14 +361,21 @@ def run_followup_cycle() -> None:
     for email in emails:
         sent_at_raw = email.get("sent_at")
         if not sent_at_raw:
+            log.warning("Follow-up cycle: skipping email with missing sent_at", email_id=email.get("id"))
             continue
 
         try:
             sent_at = datetime.fromisoformat(sent_at_raw.replace("Z", "+00:00"))
         except ValueError:
+            log.warning("Follow-up cycle: malformed sent_at value", email_id=email.get("id"), sent_at=sent_at_raw)
             continue
 
         if sent_at > cutoff:
+            continue
+
+        # Skip if follow-up already drafted — prevents duplicate drafts across scheduler runs
+        if email.get("followup_status") == "pending_followup":
+            log.info("Follow-up already pending, skipping", email_id=email.get("id"))
             continue
 
         eid = email.get("id")
@@ -391,8 +398,6 @@ def run_followup_cycle() -> None:
                 log.info("Follow-up draft created", email_id=eid, job_id=jid)
         except Exception as exc:
             _record_error(f"followup_{eid}", str(exc))
-
-        time.sleep(2)
 
     _summary["followups_drafted"] = _summary.get("followups_drafted", 0) + reminded
     log.info("Follow-up cycle complete", reminded=reminded)

--- a/scheduler/tasks.py
+++ b/scheduler/tasks.py
@@ -18,7 +18,7 @@ import json
 import os
 import subprocess
 import time
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import httpx
@@ -254,6 +254,7 @@ def run_draft_cycle() -> None:
     log.info("Draft cycle complete", drafted=drafted)
 
 
+
 # ---------------------------------------------------------------------------
 # Task 4 — Weekly digest cycle  (every Sunday at 09:00 UTC)
 # ---------------------------------------------------------------------------
@@ -323,3 +324,75 @@ def run_digest_cycle() -> None:
     )
 
     _summary["digest_sent"] = result.get("job_count", 0)
+
+
+# --------------------------------------------------------------------------
+# Follow-up scheduling cycle
+# --------------------------------------------------------------------------
+
+FOLLOWUP_DAYS = int(os.getenv("FOLLOWUP_DAYS", 7))
+
+
+def run_followup_cycle() -> None:
+    """
+    Checks for emails marked as 'sent' more than FOLLOWUP_DAYS days ago
+    that have not received a reply. For each, drafts a follow-up using
+    followup.j2 and surfaces it as a pending action in the dashboard.
+    Never sends automatically — always requires manual review.
+    """
+    log.info("Follow-up cycle started", followup_days=FOLLOWUP_DAYS)
+    reminded = 0
+
+    try:
+        with httpx.Client(timeout=httpx.Timeout(30.0, connect=10.0)) as c:
+            r = c.get(
+                f"{_gw()}/api/emails",
+                params={"status": "sent"},
+            )
+            r.raise_for_status()
+            emails = r.json()
+    except Exception as exc:
+        _record_error("followup_fetch", str(exc))
+        log.warning("Follow-up cycle: could not fetch sent emails", error=str(exc))
+        return
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=FOLLOWUP_DAYS)
+
+    for email in emails:
+        sent_at_raw = email.get("sent_at")
+        if not sent_at_raw:
+            continue
+
+        try:
+            sent_at = datetime.fromisoformat(sent_at_raw.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+
+        if sent_at > cutoff:
+            continue
+
+        eid = email.get("id")
+        jid = email.get("job_id")
+
+        log.info("Drafting follow-up", email_id=eid, job_id=jid, sent_at=sent_at_raw)
+
+        payload = {
+            "email_id": eid,
+            "job_id": jid,
+            "template": "followup",
+            "action": "pending_followup",
+        }
+
+        try:
+            with httpx.Client(timeout=httpx.Timeout(90.0, connect=10.0)) as c:
+                r = c.post(f"{_gw()}/api/generate", json=payload)
+                r.raise_for_status()
+                reminded += 1
+                log.info("Follow-up draft created", email_id=eid, job_id=jid)
+        except Exception as exc:
+            _record_error(f"followup_{eid}", str(exc))
+
+        time.sleep(2)
+
+    _summary["followups_drafted"] = _summary.get("followups_drafted", 0) + reminded
+    log.info("Follow-up cycle complete", reminded=reminded)


### PR DESCRIPTION
Closes #15

Changes:
- Added run_followup_cycle()  in tasks.py   queries emails with  status=sent  older than 7 days, drafts follow-up using  followup.j2 , stores as  pending_followup 
- Duplicate prevention  skips emails where  followup_status == pending_followup already exists
- Malformed or missing  sent_at` values are now logged with `log.warning  instead of silently skipped
-  FOLLOWUP_DAYS configurable via env var (default: 7)
- Registered as Job 4 in  build_scheduler()  runs every 24h, offset by 12h
- Never sends automatically  always requires manual review