### PR TITLE
feat(scraper): add google dork discovery flow

### DIFF
--- a/scraper-service/discovery/dork_builder.py
+++ b/scraper-service/discovery/dork_builder.py
@@ -1,0 +1,103 @@
+"""
+Configurable Google dork query generation for high-signal job discovery.
+
+The builder intentionally stays small: it creates a bounded list of search
+queries from role, stack, location, platform, and optional date constraints.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+
+
+DEFAULT_PLATFORMS: tuple[str, ...] = (
+    "company_careers",
+    "notion",
+    "github",
+    "linkedin_jobs",
+    "greenhouse",
+    "lever",
+)
+
+
+@dataclass(frozen=True)
+class JobDorkConfig:
+    role: str
+    stack: tuple[str, ...] = field(default_factory=tuple)
+    location: str | None = None
+    year: int | None = None
+    after: date | None = None
+    platforms: tuple[str, ...] = DEFAULT_PLATFORMS
+    max_queries: int = 12
+
+
+def _quote(value: str) -> str:
+    clean = " ".join(value.strip().split())
+    return f'"{clean}"'
+
+
+def _or_group(values: list[str]) -> str:
+    return "(" + " OR ".join(_quote(value) for value in values if value.strip()) + ")"
+
+
+class DorkBuilder:
+    """
+    Builds Google search queries without hardcoding feature-specific strings
+    in scraper code.
+    """
+
+    hiring_terms = ["hiring", "we are hiring", "open roles", "careers", "jobs"]
+
+    def build(self, config: JobDorkConfig) -> list[str]:
+        role = _quote(config.role)
+        stack_terms = " ".join(_quote(term) for term in config.stack if term.strip())
+        location = _quote(config.location) if config.location else ""
+        year = str(config.year) if config.year else ""
+        after = f"after:{config.after.isoformat()}" if config.after else ""
+
+        context = " ".join(
+            part for part in (role, stack_terms, location, year, after) if part
+        )
+
+        templates = {
+            "company_careers": (
+                'inurl:careers ("open roles" OR jobs OR hiring) {context}'
+            ),
+            "notion": (
+                'site:notion.so {context} {hiring_terms}'
+            ),
+            "github": (
+                'site:github.com {context} {hiring_terms}'
+            ),
+            "linkedin_jobs": (
+                'site:linkedin.com/jobs {context}'
+            ),
+            "greenhouse": (
+                'site:greenhouse.io {context}'
+            ),
+            "lever": (
+                'site:jobs.lever.co {context}'
+            ),
+        }
+
+        queries: list[str] = []
+        seen: set[str] = set()
+        hiring_terms = _or_group(self.hiring_terms)
+
+        for platform in config.platforms:
+            template = templates.get(platform)
+            if not template:
+                continue
+
+            query = " ".join(
+                template.format(context=context, hiring_terms=hiring_terms).split()
+            )
+            if query and query not in seen:
+                queries.append(query)
+                seen.add(query)
+
+            if len(queries) >= config.max_queries:
+                break
+
+        return queries

--- a/scraper-service/discovery/dork_discovery.py
+++ b/scraper-service/discovery/dork_discovery.py
@@ -1,0 +1,151 @@
+"""
+Search provider orchestration for Google dork discovery.
+
+External APIs are optional. If no provider is configured, the service still
+returns generated queries so the flow is testable without a paid dependency.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Protocol
+
+from .dork_builder import DorkBuilder, JobDorkConfig
+from .dork_filter import DiscoveryCandidate, DiscoveryFilter, RawSearchResult
+
+
+class SearchProvider(Protocol):
+    async def search(self, query: str, limit: int = 10) -> list[RawSearchResult]:
+        ...
+
+
+class SerperSearchProvider:
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+
+    async def search(self, query: str, limit: int = 10) -> list[RawSearchResult]:
+        import httpx
+
+        async with httpx.AsyncClient(timeout=20) as client:
+            response = await client.post(
+                "https://google.serper.dev/search",
+                headers={"X-API-KEY": self.api_key, "Content-Type": "application/json"},
+                json={"q": query, "num": limit},
+            )
+            response.raise_for_status()
+
+        payload = response.json()
+        organic = payload.get("organic") or []
+        return [
+            RawSearchResult(
+                title=item.get("title") or "",
+                url=item.get("link") or "",
+                snippet=item.get("snippet") or "",
+                query=query,
+            )
+            for item in organic
+        ]
+
+
+class GoogleCseSearchProvider:
+    def __init__(self, api_key: str, cx: str) -> None:
+        self.api_key = api_key
+        self.cx = cx
+
+    async def search(self, query: str, limit: int = 10) -> list[RawSearchResult]:
+        import httpx
+
+        async with httpx.AsyncClient(timeout=20) as client:
+            response = await client.get(
+                "https://www.googleapis.com/customsearch/v1",
+                params={"key": self.api_key, "cx": self.cx, "q": query, "num": limit},
+            )
+            response.raise_for_status()
+
+        payload = response.json()
+        return [
+            RawSearchResult(
+                title=item.get("title") or "",
+                url=item.get("link") or "",
+                snippet=item.get("snippet") or "",
+                query=query,
+            )
+            for item in payload.get("items") or []
+        ]
+
+
+class SeedSearchProvider:
+    """
+    Local fallback for demos/tests. DORK_SEED_RESULTS should be JSON shaped as:
+    [{"title": "...", "url": "...", "snippet": "..."}]
+    """
+
+    def __init__(self, results: list[dict[str, str]]) -> None:
+        self.results = results
+
+    async def search(self, query: str, limit: int = 10) -> list[RawSearchResult]:
+        return [
+            RawSearchResult(
+                title=item.get("title", ""),
+                url=item.get("url", ""),
+                snippet=item.get("snippet", ""),
+                query=query,
+            )
+            for item in self.results[:limit]
+        ]
+
+
+def provider_from_env() -> SearchProvider | None:
+    serper_key = os.environ.get("SERPER_API_KEY")
+    if serper_key:
+        return SerperSearchProvider(serper_key)
+
+    google_key = os.environ.get("GOOGLE_CSE_API_KEY")
+    google_cx = os.environ.get("GOOGLE_CSE_ID")
+    if google_key and google_cx:
+        return GoogleCseSearchProvider(google_key, google_cx)
+
+    seed_json = os.environ.get("DORK_SEED_RESULTS")
+    if seed_json:
+        return SeedSearchProvider(json.loads(seed_json))
+
+    return None
+
+
+@dataclass(frozen=True)
+class DiscoveryResponse:
+    queries: list[str]
+    candidates: list[DiscoveryCandidate]
+
+
+class DorkDiscoveryService:
+    def __init__(
+        self,
+        provider: SearchProvider | None = None,
+        builder: DorkBuilder | None = None,
+        result_filter: DiscoveryFilter | None = None,
+    ) -> None:
+        self.provider = provider
+        self.builder = builder or DorkBuilder()
+        self.result_filter = result_filter or DiscoveryFilter()
+
+    async def discover(
+        self,
+        config: JobDorkConfig,
+        results_per_query: int = 10,
+    ) -> DiscoveryResponse:
+        queries = self.builder.build(config)
+        if not self.provider:
+            return DiscoveryResponse(queries=queries, candidates=[])
+
+        candidates: list[DiscoveryCandidate] = []
+        for query in queries:
+            raw_results = await self.provider.search(query, limit=results_per_query)
+            for result in raw_results:
+                decision = self.result_filter.evaluate(result)
+                if decision.accepted and decision.candidate:
+                    candidates.append(decision.candidate)
+
+        return DiscoveryResponse(queries=queries, candidates=candidates)

--- a/scraper-service/discovery/dork_filter.py
+++ b/scraper-service/discovery/dork_filter.py
@@ -1,0 +1,135 @@
+"""
+Lightweight filtering and deduplication for discovered search results.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha1
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+
+TRACKING_PREFIXES = ("utm_",)
+TRACKING_KEYS = {"fbclid", "gclid", "mc_cid", "mc_eid", "ref", "ref_src"}
+
+
+@dataclass(frozen=True)
+class RawSearchResult:
+    title: str
+    url: str
+    snippet: str = ""
+    query: str = ""
+
+
+@dataclass(frozen=True)
+class DiscoveryCandidate:
+    title: str
+    url: str
+    snippet: str
+    query: str
+    score: int
+
+
+@dataclass(frozen=True)
+class FilterDecision:
+    accepted: bool
+    reason: str
+    candidate: DiscoveryCandidate | None = None
+
+
+class UrlDeduplicator:
+    def __init__(self) -> None:
+        self._seen: set[str] = set()
+
+    def seen(self, url: str) -> bool:
+        digest = sha1(url.encode("utf-8")).hexdigest()
+        if digest in self._seen:
+            return True
+        self._seen.add(digest)
+        return False
+
+
+class DiscoveryFilter:
+    high_signal_terms = {
+        "apply",
+        "career",
+        "careers",
+        "hiring",
+        "job",
+        "jobs",
+        "open role",
+        "open roles",
+        "position",
+        "responsibilities",
+    }
+    noisy_terms = {
+        "course",
+        "interview question",
+        "salary guide",
+        "template",
+        "tutorial",
+        "webinar",
+    }
+    blocked_domains = {
+        "youtube.com",
+        "youtu.be",
+        "facebook.com",
+        "instagram.com",
+        "pinterest.com",
+    }
+
+    def __init__(self, min_score: int = 2) -> None:
+        self.min_score = min_score
+        self.deduper = UrlDeduplicator()
+
+    def evaluate(self, result: RawSearchResult) -> FilterDecision:
+        normalized_url = self.normalize_url(result.url)
+        if not normalized_url:
+            return FilterDecision(False, "missing_url")
+
+        domain = urlsplit(normalized_url).netloc.lower().removeprefix("www.")
+        if any(domain == bad or domain.endswith(f".{bad}") for bad in self.blocked_domains):
+            return FilterDecision(False, "blocked_domain")
+
+        if self.deduper.seen(normalized_url):
+            return FilterDecision(False, "duplicate_url")
+
+        text = f"{result.title} {result.snippet} {normalized_url}".lower()
+        if any(term in text for term in self.noisy_terms):
+            return FilterDecision(False, "noisy_term")
+
+        score = sum(1 for term in self.high_signal_terms if term in text)
+        if score < self.min_score:
+            return FilterDecision(False, "low_signal")
+
+        return FilterDecision(
+            True,
+            "accepted",
+            DiscoveryCandidate(
+                title=result.title.strip(),
+                url=normalized_url,
+                snippet=result.snippet.strip(),
+                query=result.query,
+                score=score,
+            ),
+        )
+
+    @staticmethod
+    def normalize_url(url: str) -> str:
+        clean = url.strip()
+        if not clean:
+            return ""
+
+        parts = urlsplit(clean)
+        if parts.scheme not in {"http", "https"} or not parts.netloc:
+            return ""
+
+        query = [
+            (key, value)
+            for key, value in parse_qsl(parts.query, keep_blank_values=True)
+            if key not in TRACKING_KEYS
+            and not any(key.startswith(prefix) for prefix in TRACKING_PREFIXES)
+        ]
+        normalized_query = urlencode(query, doseq=True)
+        path = parts.path.rstrip("/") or "/"
+        return urlunsplit((parts.scheme, parts.netloc.lower(), path, normalized_query, ""))

--- a/scraper-service/main.py
+++ b/scraper-service/main.py
@@ -12,14 +12,19 @@ from __future__ import annotations
 import asyncio
 import logging
 from contextlib import asynccontextmanager
+from datetime import date
+from typing import Any
 
 from fastapi import FastAPI, BackgroundTasks
 from pydantic import BaseModel
 
 import emit as emitter
+from discovery.dork_builder import DEFAULT_PLATFORMS, JobDorkConfig
+from discovery.dork_discovery import DorkDiscoveryService, provider_from_env
 from scrapers.naukri import NaukriScraper
 from scrapers.linkedin import LinkedInScraper
 from scrapers.internshala import IntershalaScraper
+from scrapers.google_dork import GoogleDorkScraper
 
 logging.basicConfig(
     level=logging.INFO,
@@ -27,7 +32,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-PLATFORMS = ["naukri", "linkedin", "internshala"]
+PLATFORMS = ["naukri", "linkedin", "internshala", "google_dork"]
 
 
 # ---------------------------------------------------------------------------
@@ -69,6 +74,22 @@ class ScrapeResponse(BaseModel):
     platforms: list[str]
 
 
+class DorkDiscoverRequest(BaseModel):
+    role: str = "Backend Engineer"
+    stack: list[str] = []
+    location: str | None = None
+    year: int | None = None
+    after: date | None = None
+    platforms: list[str] = []
+    max_queries: int = 8
+    results_per_query: int = 10
+
+
+class DorkDiscoverResponse(BaseModel):
+    queries: list[str]
+    candidates: list[dict[str, Any]]
+
+
 # ---------------------------------------------------------------------------
 # Background scrape runner
 # ---------------------------------------------------------------------------
@@ -82,6 +103,7 @@ async def _run_all_scrapers(role: str, stack: list[str]) -> None:
         NaukriScraper(),
         LinkedInScraper(),
         IntershalaScraper(),
+        GoogleDorkScraper(),
     ]
 
     # Run all scrapers in parallel; capture per-scraper exceptions.
@@ -122,3 +144,37 @@ async def trigger_scrape(body: ScrapeRequest, background_tasks: BackgroundTasks)
     """
     background_tasks.add_task(_run_all_scrapers, body.role, body.stack)
     return ScrapeResponse(triggered=True, platforms=PLATFORMS)
+
+
+@app.post("/discover/dorks", response_model=DorkDiscoverResponse, tags=["discovery"])
+async def discover_dorks(body: DorkDiscoverRequest):
+    """
+    Generate dork queries and, when a provider is configured, return filtered
+    discovery candidates. This endpoint is demo-friendly and does not emit jobs.
+    """
+    config = JobDorkConfig(
+        role=body.role,
+        stack=tuple(body.stack),
+        location=body.location,
+        year=body.year,
+        after=body.after,
+        platforms=tuple(body.platforms) or DEFAULT_PLATFORMS,
+        max_queries=body.max_queries,
+    )
+    response = await DorkDiscoveryService(provider=provider_from_env()).discover(
+        config,
+        results_per_query=body.results_per_query,
+    )
+    return DorkDiscoverResponse(
+        queries=response.queries,
+        candidates=[
+            {
+                "title": candidate.title,
+                "url": candidate.url,
+                "snippet": candidate.snippet,
+                "query": candidate.query,
+                "score": candidate.score,
+            }
+            for candidate in response.candidates
+        ],
+    )

--- a/scraper-service/scrapers/google_dork.py
+++ b/scraper-service/scrapers/google_dork.py
@@ -1,0 +1,88 @@
+"""
+Google dork discovery adapter for the platform scraper service.
+
+This scraper keeps external search APIs optional. Without SERPER_API_KEY,
+GOOGLE_CSE_API_KEY/GOOGLE_CSE_ID, or DORK_SEED_RESULTS it only logs generated
+queries and emits no jobs.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import date
+from urllib.parse import urlsplit
+
+from discovery.dork_builder import DEFAULT_PLATFORMS, JobDorkConfig
+from discovery.dork_discovery import DorkDiscoveryService, provider_from_env
+from scrapers.base import PlatformScraper
+
+logger = logging.getLogger(__name__)
+
+
+def _company_from_url(url: str) -> str:
+    host = urlsplit(url).netloc.lower().removeprefix("www.")
+    parts = host.split(".")
+    if len(parts) >= 3 and parts[0] in {"careers", "jobs"}:
+        return parts[1].replace("-", " ").title()
+    if len(parts) >= 2:
+        return parts[-2].replace("-", " ").title()
+    return host or "Unknown Company"
+
+
+def _parse_after(value: str | None) -> date | None:
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        logger.warning("Ignoring invalid DORK_AFTER date: %s", value)
+        return None
+
+
+class GoogleDorkScraper(PlatformScraper):
+    source_name = "google_dork"
+
+    async def scrape(self, role: str, stack: list[str]) -> list[dict]:
+        platforms = tuple(
+            item.strip()
+            for item in os.environ.get("DORK_PLATFORMS", "").split(",")
+            if item.strip()
+        )
+        config = JobDorkConfig(
+            role=role,
+            stack=tuple(stack),
+            location=os.environ.get("DORK_LOCATION"),
+            year=int(os.environ["DORK_YEAR"]) if os.environ.get("DORK_YEAR") else None,
+            after=_parse_after(os.environ.get("DORK_AFTER")),
+            platforms=platforms or DEFAULT_PLATFORMS,
+            max_queries=int(os.environ.get("DORK_MAX_QUERIES", "8")),
+        )
+
+        service = DorkDiscoveryService(provider=provider_from_env())
+        response = await service.discover(
+            config,
+            results_per_query=int(os.environ.get("DORK_RESULTS_PER_QUERY", "10")),
+        )
+
+        logger.info("[GoogleDork] Generated %d queries", len(response.queries))
+        for query in response.queries:
+            logger.info("[GoogleDork] query: %s", query)
+
+        jobs: list[dict] = []
+        for candidate in response.candidates:
+            jobs.append(
+                {
+                    "company": _company_from_url(candidate.url),
+                    "role": candidate.title or role,
+                    "source": self.source_name,
+                    "url": candidate.url,
+                    "stack": stack,
+                    "product": None,
+                    "location": config.location,
+                    "posted_at": None,
+                }
+            )
+
+        logger.info("[GoogleDork] Accepted %d discovered URLs", len(jobs))
+        return jobs

--- a/scraper-service/tests/test_dork_builder.py
+++ b/scraper-service/tests/test_dork_builder.py
@@ -1,0 +1,55 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from discovery.dork_builder import DorkBuilder, JobDorkConfig
+from discovery.dork_filter import DiscoveryFilter, RawSearchResult
+
+
+def test_dork_builder_generates_platform_queries():
+    config = JobDorkConfig(
+        role="backend engineer",
+        stack=("Go", "Kubernetes"),
+        location="Bangalore",
+        year=2026,
+        platforms=("notion", "company_careers"),
+    )
+
+    queries = DorkBuilder().build(config)
+
+    assert len(queries) == 2
+    assert 'site:notion.so "backend engineer" "Go" "Kubernetes" "Bangalore" 2026' in queries[0]
+    assert "inurl:careers" in queries[1]
+
+
+def test_dork_filter_accepts_high_signal_career_result_once():
+    result_filter = DiscoveryFilter(min_score=2)
+    result = RawSearchResult(
+        title="Backend Engineer - Open Roles",
+        url="https://careers.example.com/jobs/backend?utm_source=google",
+        snippet="We are hiring. Apply for this backend engineer position.",
+        query="example query",
+    )
+
+    first = result_filter.evaluate(result)
+    second = result_filter.evaluate(result)
+
+    assert first.accepted is True
+    assert first.candidate is not None
+    assert first.candidate.url == "https://careers.example.com/jobs/backend"
+    assert second.accepted is False
+    assert second.reason == "duplicate_url"
+
+
+def test_dork_filter_rejects_noisy_result():
+    decision = DiscoveryFilter().evaluate(
+        RawSearchResult(
+            title="Backend engineer interview questions",
+            url="https://blog.example.com/backend-interview",
+            snippet="A tutorial and salary guide for candidates.",
+        )
+    )
+
+    assert decision.accepted is False
+    assert decision.reason == "noisy_term"


### PR DESCRIPTION
## Summary
Adds a lightweight Google dorking discovery flow for high-signal job discovery.

## What changed
- Added template-based dork query generation
- Added optional search provider support via Serper and Google Custom Search
- Kept external APIs optional, so the core flow has no paid API hard dependency
- Added lightweight URL normalization, deduplication, and noisy-result filtering
- Integrated Google dork discovery into scraper-service
- Added a demo-friendly /discover/dorks endpoint for generated queries and filtered candidates
- Added unit coverage for query generation, filtering, and duplicate handling

## Example generated queries
- site:notion.so "backend engineer" "Go" "Kubernetes" "Bangalore" 2026 ("hiring" OR "we are hiring" OR "open roles" OR "careers" OR "jobs")
- inurl:careers ("open roles" OR jobs OR hiring) "backend engineer" "Go" "Kubernetes" "Bangalore" 2026
- site:github.com "backend engineer" "Go" "Kubernetes" "Bangalore" 2026 ("hiring" OR "we are hiring" OR "open roles" OR "careers" OR "jobs")
- site:linkedin.com/jobs "backend engineer" "Go" "Kubernetes" "Bangalore" 2026

## Filtering examples
The filtering layer accepts results with hiring/apply/career/open-role signals and rejects:
- duplicate normalized URLs
- blocked/noisy domains
- tutorial/course/interview-question/salary-guide style pages
- low-signal pages without enough job intent

## Pipeline flow
1. /scrape runs the existing platform scrapers plus GoogleDorkScraper
2. GoogleDorkScraper generates dork queries from role + stack + optional location/year/date filters
3. If a provider is configured, results are fetched and filtered
4. Accepted URLs are mapped to the existing job event shape
5. Jobs are emitted through the existing Redis stream into the current aggregation pipeline

## Verification
- py_compile passed for the new discovery modules and scraper integration
- Manual query/filter assertions passed
- git diff --check passed