### PR TITLE
feat: add Redis-backed SMTP rate limiting, email caching, and provide…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
 /.env
+arachnode/contact-discovery-service/.venv
+.venv
+bash.env
+.env.local
+.env.*.local
 
 # Python bytecode and caches
 __pycache__/

--- a/contact-discovery-service/verifier.py
+++ b/contact-discovery-service/verifier.py
@@ -8,7 +8,7 @@ How it works:
   4. Close without DATA — no email is ever sent.
 
 Rate limiting:
-  To avoid being blocklisted, we allow a maximum of 5 verification attempts
+  To avoid being blocklisted, we allow a maximum of 3 verification attempts
   per domain per hour.  A simple in-memory dict tracks this; for multi-process
   deployments swap it for a Redis counter.
 
@@ -23,6 +23,7 @@ Verification results:
 
 from __future__ import annotations
 
+import os
 import asyncio
 import logging
 import smtplib
@@ -30,38 +31,134 @@ import socket
 import time
 from collections import defaultdict
 from typing import Literal
+from redis.asyncio import Redis, RedisError
 
 logger = logging.getLogger(__name__)
 
 VerifyResult = Literal["verified", "unverified", "invalid"]
 
+REDIS_URL: str = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+
+# One connection pool shared across all coroutines in this process.
+_redis: Redis = Redis.from_url(
+    REDIS_URL,
+    encoding="utf-8",
+    decode_responses=True,
+)
+ 
+# Key prefixes — easy to namespace if you share a Redis instance.
+_KEY_CACHE = "verifier:result:"    # verifier:result:<email>
+_KEY_RATE  = "verifier:rate:"      # verifier:rate:<domain>
+
 # Per-domain rate limit: (count, window_start)
 _domain_rate: dict[str, tuple[int, float]] = defaultdict(lambda: (0, time.time()))
-_MAX_PER_DOMAIN_PER_HOUR = 5
-_WINDOW_SECONDS = 3600
-_SMTP_TIMEOUT = 5   # seconds
+_MAX_PER_DOMAIN_PER_HOUR = int(os.getenv("VERIFIER_MAX_PER_DOMAIN_PER_HOUR", "3"))
+_WINDOW_SECONDS = int(os.getenv("VERIFIER_WINDOW_SECONDS", "3600"))
+_SMTP_TIMEOUT = int(os.getenv("VERIFIER_SMTP_TIMEOUT", "5"))
+_CACHE_TTL_SECONDS = int(os.getenv("VERIFIER_CACHE_TTL_SECONDS", "86400"))
+# ---------------------------------------------------------------------------
+# Default blocklist – providers known to fake or block SMTP verification
+# ---------------------------------------------------------------------------
+# Grouped by vendor so additions stay readable and reviewable.
+_PROVIDER_BLOCKLIST: dict[str, set[str]] = {
+    "google":    {"gmail.com", "googlemail.com"},
+    "microsoft": {"outlook.com", "hotmail.com", "live.com", "msn.com", "passport.com"},
+    "yahoo":     {"yahoo.com", "yahoo.co.uk", "yahoo.co.in", "ymail.com"},
+    "apple":     {"icloud.com", "me.com", "mac.com"},
+    "misc":      {
+        "protonmail.com", "proton.me", "zoho.com", "aol.com",
+        "fastmail.com", "fastmail.fm", "hey.com",
+        "tutanota.com", "tutanota.de",
+    },
+}
+
+_DEFAULT_BLOCKLIST: frozenset[str] = frozenset(
+    domain for domains in _PROVIDER_BLOCKLIST.values() for domain in domains
+)
+
+# ---------------------------------------------------------------------------
+# Environment-based extension
+# ---------------------------------------------------------------------------
+# Set VERIFIER_SMTP_BLOCKLIST_EXTENDS to a comma-separated list of extra
+# domains that should be treated the same as the built-ins, e.g.:
+#   VERIFIER_SMTP_BLOCKLIST_EXTENDS=example.com,disposable.net
+# ---------------------------------------------------------------------------
+def _load_env_blocklist(env_var: str = "VERIFIER_SMTP_BLOCKLIST_EXTENDS") -> frozenset[str]:
+    raw = os.getenv(env_var, "")
+    return frozenset(d.strip().lower() for d in raw.split(",") if d.strip())
 
 
-def _rate_allowed(domain: str) -> bool:
-    """Return True if we have quota left for this domain this hour."""
-    count, window_start = _domain_rate[domain]
-    now = time.time()
-    if now - window_start > _WINDOW_SECONDS:
-        # Window expired — reset
-        _domain_rate[domain] = (0, now)
+def build_smtp_blocklist(
+    *,
+    extra_domains: frozenset[str] | set[str] | None = None,
+    env_var: str = "VERIFIER_SMTP_BLOCKLIST_EXTENDS",
+) -> frozenset[str]:
+    """
+    Compose the final SMTP blocklist from three sources (lowest → highest priority):
+
+    1. ``_DEFAULT_BLOCKLIST``  – the hardcoded vendor groups above.
+    2. ``VERIFIER_SMTP_BLOCKLIST_EXTENDS`` env var – ops/infra overrides at deploy time.
+    3. ``extra_domains`` kwarg – programmatic overrides from calling code or tests.
+    """
+    env_domains = _load_env_blocklist(env_var)
+    caller_domains = frozenset(d.lower() for d in (extra_domains or set()))
+    return _DEFAULT_BLOCKLIST | env_domains | caller_domains
+
+
+# Module-level singleton – used by default; callers can build their own.
+SMTP_BLOCKLIST: frozenset[str] = build_smtp_blocklist()
+
+async def _cache_get(email: str) -> VerifyResult | None:
+    """Return the cached result for *email*, or None on miss / Redis error."""
+    try:
+        value = await _redis.get(f"{_KEY_CACHE}{email}")
+        if value is not None:
+            logger.debug("[Verifier] Cache hit for %s → %s", email, value)
+            return value  # type: ignore[return-value]
+        return None
+    except RedisError as exc:
+        logger.warning("[Verifier] Redis cache GET failed: %s", exc)
+        return None
+ 
+ 
+async def _cache_set(email: str, result: VerifyResult) -> None:
+    """Persist a definitive result in Redis.  'unverified' is never cached."""
+    if result == "unverified":
+        return
+    try:
+        await _redis.set(f"{_KEY_CACHE}{email}", result, ex=_CACHE_TTL_SECONDS)
+    except RedisError as exc:
+        logger.warning("[Verifier] Redis cache SET failed: %s", exc)
+
+
+async def _rate_check_and_increment(domain: str) -> bool:
+    """
+    Atomically increment the per-domain counter and return True if the request
+    is within quota, False if the limit has been reached.
+ 
+    Uses the standard INCR + EXPIRE pattern
+    """
+    key = f"{_KEY_RATE}{domain}"
+    try:
+        count = await _redis.incr(key)
+        if count == 1:
+            # First probe in this window — set the expiry.
+            await _redis.expire(key, _WINDOW_SECONDS)
+        if count > _MAX_PER_DOMAIN_PER_HOUR:
+            logger.warning(
+                "[Verifier] Rate limit reached for domain '%s' (%d/hr). Skipping.",
+                domain,
+                _MAX_PER_DOMAIN_PER_HOUR,
+            )
+            # Roll back the increment so we don't over-count.
+            await _redis.decr(key)
+            return False
         return True
-    if count >= _MAX_PER_DOMAIN_PER_HOUR:
-        logger.warning(
-            "[Verifier] Rate limit reached for domain '%s' (%d/hr). Skipping.",
-            domain, _MAX_PER_DOMAIN_PER_HOUR,
-        )
-        return False
-    return True
+    except RedisError as exc:
+        # If Redis is down, fail open so legitimate checks aren't silently dropped.
+        logger.warning("[Verifier] Redis rate-limit check failed, failing open: %s", exc)
+        return True
 
-
-def _increment_rate(domain: str) -> None:
-    count, window_start = _domain_rate[domain]
-    _domain_rate[domain] = (count + 1, window_start)
 
 
 def _resolve_mx(domain: str) -> str | None:
@@ -122,18 +219,32 @@ async def verify_email(email: str) -> VerifyResult:
 
     domain = email.split("@", 1)[1].lower()
 
-    if not _rate_allowed(domain):
+    # 1. Cache look-up
+    cached = await _cache_get(email)
+    if cached is not None:
+        return cached
+ 
+    # 2. Blocklist check
+    if domain in SMTP_BLOCKLIST:
+        logger.info("[Verifier] %s is on the SMTP blocklist — skipping probe.", domain)
         return "unverified"
+ 
+    # 3. Rate limit (atomic check-and-increment)
+    if not await _rate_check_and_increment(domain):
+        return "unverified"
+
 
     mx_host = _resolve_mx(domain)
     if not mx_host:
         logger.debug("[Verifier] No MX record found for %s", domain)
         return "unverified"
 
-    _increment_rate(domain)
     loop = asyncio.get_running_loop()
     result: VerifyResult = await loop.run_in_executor(
         None, _smtp_check_sync, email, mx_host
     )
     logger.info("[Verifier] %s → %s (via %s)", email, result, mx_host)
+
+    await _cache_set(email, result)
+
     return result


### PR DESCRIPTION
closes #12 

- Migrate rate limiting from in-memory to Redis (atomic INCR + EXPIRE)
- Add per-domain rate limit: 3 verification attempts per hour
- Implement Redis-backed result cache with 24h TTL
- Skip caching transient 'unverified' states (network failures)
- Add SMTP blocklist for known providers (Gmail, Outlook, Yahoo, iCloud, etc.)
- Allow blocklist extension via VERIFIER_SMTP_BLOCKLIST_EXTENDS env var
- Graceful degradation when Redis is unavailable (fail open, log warnings)
- Works across multiple workers/processes