### PR TITLE
Add centralized date normalization utility for aggregator ingestion

### DIFF
--- a/aggregator-service/consumer.py
+++ b/aggregator-service/consumer.py
@@ -18,6 +18,7 @@ import logging
 import os
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
+from utils.date_utils import normalize_date
 
 import redis.asyncio as aioredis
 
@@ -48,23 +49,6 @@ def _dedup_key(company: str, role: str) -> str:
     raw = _normalise(company) + "|" + _normalise(role)
     md5 = hashlib.md5(raw.encode()).hexdigest()
     return f"dedup:agg:{md5}"
-
-
-def _parse_posted_at(value: Optional[str]) -> Optional[datetime]:
-    if not value:
-        return None
-    for fmt in ("%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%d"):
-        try:
-            dt = datetime.strptime(value, fmt)
-            return dt.replace(tzinfo=timezone.utc)
-        except ValueError:
-            continue
-    try:
-        # ISO 8601 with timezone offset
-        return datetime.fromisoformat(value)
-    except ValueError:
-        logger.warning("Cannot parse posted_at=%r — storing NULL", value)
-        return None
 
 
 # ---------------------------------------------------------------------------
@@ -123,7 +107,7 @@ async def _process_message(
     except (json.JSONDecodeError, TypeError):
         stack = None
 
-    posted_at = _parse_posted_at(data.get("posted_at"))
+    posted_at = normalize_date(data.get("posted_at"))
 
     row = await database.insert_job(
         pool,

--- a/aggregator-service/db.py
+++ b/aggregator-service/db.py
@@ -114,7 +114,7 @@ async def insert_job(
     """
     sql = """
         INSERT INTO jobs (company, role, source, url, stack, product, location, posted_at)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, COALESCE($8, NOW()))
         ON CONFLICT DO NOTHING
         RETURNING *
     """

--- a/aggregator-service/utils/date_utils.py
+++ b/aggregator-service/utils/date_utils.py
@@ -1,0 +1,208 @@
+"""
+Centralized date normalization for the aggregator.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Optional, Union
+
+logger = logging.getLogger(__name__)
+
+
+DateInput = Optional[Union[str, int, float, datetime]]
+
+_EXPLICIT_FORMATS = [
+    # ISO-like without tz
+    "%Y-%m-%dT%H:%M:%S",
+    "%Y-%m-%dT%H:%M:%SZ",
+    "%Y-%m-%d %H:%M:%S",
+    "%Y-%m-%d",
+    # Human-readable locale strings
+    "%b %d, %Y",        # Jun 1, 2024
+    "%B %d, %Y",        # June 1, 2024
+    "%d %b %Y",         # 01 Jun 2024
+    "%d %B %Y",         # 01 June 2024
+    "%B %d %Y",         # June 1 2024  
+    "%b %d %Y",         # Jun 1 2024
+    "%d-%m-%Y",         # 01-06-2024 
+                        
+]
+
+_RELATIVE_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"^just\s*now$", re.I),                              "now"),
+    (re.compile(r"^today$", re.I),                                   "now"),
+    (re.compile(r"^yesterday$", re.I),                               "days:1"),
+    (re.compile(r"^(\d+)\s+second[s]?\s+ago$", re.I),               "seconds"),
+    (re.compile(r"^(\d+)\s+minute[s]?\s+ago$", re.I),               "minutes"),
+    (re.compile(r"^(\d+)\s+hour[s]?\s+ago$", re.I),                 "hours"),
+    (re.compile(r"^(\d+)\s+day[s]?\s+ago$", re.I),                  "days"),
+    (re.compile(r"^(\d+)\s+week[s]?\s+ago$", re.I),                 "weeks"),
+    (re.compile(r"^(\d+)\s+month[s]?\s+ago$", re.I),                "months"),
+]
+
+# Heuristic threshold
+_MS_THRESHOLD = 1e10
+
+# Internal helpers
+
+
+def _utcnow() -> datetime:
+    """Current UTC time.  Isolated so tests can monkeypatch it."""
+    return datetime.now(tz=timezone.utc)
+
+
+def _to_utc(dt: datetime) -> datetime:
+    """Attach UTC if naive, convert to UTC if offset-aware."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _try_iso8601(value: str) -> Optional[datetime]:
+   
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return _to_utc(dt)
+    except ValueError:
+        return None
+
+
+def _try_explicit_formats(value: str) -> Optional[datetime]:
+
+    for fmt in _EXPLICIT_FORMATS:
+        try:
+            dt = datetime.strptime(value, fmt)
+            return _to_utc(dt)
+        
+        except ValueError:
+            continue
+    return None
+
+
+def _try_unix_timestamp(value: Union[str, int, float]) -> Optional[datetime]:
+  
+    try:
+        ts = float(value)
+
+    except (TypeError, ValueError):
+        return None
+
+    now_s = time.time()
+    if ts < 0:
+        return None
+
+    if ts > _MS_THRESHOLD:
+        ts /= 1000.0  
+
+  
+    if ts > now_s + 50 * 365.25 * 86400:
+
+        logger.warning("normalize_date: timestamp %s is implausibly far in the future — skipping", value)
+        return None
+
+    try:
+        return datetime.fromtimestamp(ts, tz=timezone.utc)
+    except (OSError, OverflowError, ValueError):
+        return None
+
+
+def _try_relative(value: str) -> Optional[datetime]:
+ 
+    v = value.strip()
+    now = _utcnow()
+
+    for pattern, unit in _RELATIVE_PATTERNS:
+        m = pattern.match(v)
+        if m is None:
+            continue
+
+        if unit == "now":
+            return now
+
+        if unit == "days:1":          
+            return now - timedelta(days=1)
+
+        n = int(m.group(1))
+
+        if unit == "seconds":
+            return now - timedelta(seconds=n)
+        
+        if unit == "minutes":
+            return now - timedelta(minutes=n) 
+        
+        if unit == "hours":
+            return now - timedelta(hours=n)
+        
+        if unit == "days":
+            return now - timedelta(days=n)
+        
+        if unit == "weeks":
+            return now - timedelta(weeks=n)
+        
+        if unit == "months":
+
+            return now - timedelta(days=n * 30)
+
+    return None
+
+
+def normalize_date(value: DateInput) -> Optional[datetime]:
+
+
+    if isinstance(value, datetime):
+        return _to_utc(value)
+
+    
+    if value is None:
+        return None
+    if isinstance(value, str) and not value.strip():
+        return None
+
+    # Numeric types
+    if isinstance(value, (int, float)):
+        result = _try_unix_timestamp(value)
+        if result is None:
+            logger.warning("normalize_date: could not parse numeric value %r", value)
+        return result
+
+    # String that looks purely numeric 
+    if isinstance(value, str):
+        stripped = value.strip()
+
+        if re.fullmatch(r"-?\d+(\.\d+)?", stripped):
+            result = _try_unix_timestamp(stripped)
+            if result is None:
+                logger.warning("normalize_date: numeric string %r failed timestamp parse", stripped)
+            return result
+
+        # ISO 8601 with tz offset
+        if "T" in stripped or stripped.endswith("Z"):
+            result = _try_iso8601(stripped)
+            if result is not None:
+                return result
+           
+
+        # Explicit formats
+        result = _try_explicit_formats(stripped)
+        if result is not None:
+            return result
+
+        # Relative strings
+        result = _try_relative(stripped)
+        if result is not None:
+            return result
+
+   
+        logger.warning(
+            "normalize_date: unrecognized date string %r — will fall back to created_at",
+            stripped,
+        )
+        return None
+
+    # Unexpected type
+    logger.warning("normalize_date: unexpected type %s for value %r", type(value).__name__, value)
+    return None

--- a/aggregator-service/utils/test_date_utils.py
+++ b/aggregator-service/utils/test_date_utils.py
@@ -1,0 +1,317 @@
+"""
+pytest suite for normalize_date().
+
+Run from repo root:
+    pytest aggregator/utils/test_date_utils.py -v
+
+All tests are pure-stdlib — no extra dependencies beyond pytest itself.
+The _utcnow helper in date_utils is monkeypatched.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from utils.date_utils import normalize_date
+
+
+
+FAKE_NOW = datetime(2024, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def freeze_now(monkeypatch):
+    """Patch _utcnow so every relative-date assertion is deterministic."""
+    monkeypatch.setattr("utils.date_utils._utcnow", lambda: FAKE_NOW)
+
+
+
+# Helper
+
+
+
+def utc(year, month, day, hour=0, minute=0, second=0) -> datetime:
+    return datetime(year, month, day, hour, minute, second, tzinfo=timezone.utc)
+
+
+
+class TestGuardCases:
+    def test_none_returns_none(self):
+
+        assert normalize_date(None) is None
+
+    def test_empty_string_returns_none(self):
+
+        assert normalize_date("") is None
+
+    def test_whitespace_only_returns_none(self):
+
+        assert normalize_date("   ") is None
+
+
+
+# ISO 8601 strings
+
+
+
+class TestISO8601:
+    def test_date_only(self):
+        assert normalize_date("2024-06-01") == utc(2024, 6, 1)
+
+    def test_datetime_no_tz(self):
+        assert normalize_date("2024-06-01T12:30:00") == utc(2024, 6, 1, 12, 30, 0)
+
+    def test_datetime_with_z(self):
+        assert normalize_date("2024-06-01T12:30:00Z") == utc(2024, 6, 1, 12, 30, 0)
+
+    def test_datetime_with_positive_offset(self):
+      
+        result = normalize_date("2024-06-01T18:00:00+05:30")
+        assert result == utc(2024, 6, 1, 12, 30, 0)
+
+    def test_datetime_with_negative_offset(self):
+        result = normalize_date("2024-06-01T07:00:00-05:00")
+        assert result == utc(2024, 6, 1, 12, 0, 0)
+
+    def test_datetime_utc_plus_zero(self):
+        assert normalize_date("2024-06-01T12:00:00+00:00") == utc(2024, 6, 1, 12)
+
+    def test_result_is_utc_aware(self):
+
+        result = normalize_date("2024-06-01")
+        assert result.tzinfo is not None
+        assert result.utcoffset().total_seconds() == 0
+
+
+
+# Unix timestamps
+
+
+
+class TestUnixTimestamps:
+
+    TS_SEC = 1_717_200_000
+    TS_MS  = 1_717_200_000_000
+
+    def test_integer_seconds(self):
+        assert normalize_date(self.TS_SEC) == utc(2024, 6, 1)
+
+    def test_float_seconds(self):
+        assert normalize_date(float(self.TS_SEC)) == utc(2024, 6, 1)
+
+    def test_integer_milliseconds(self):
+        assert normalize_date(self.TS_MS) == utc(2024, 6, 1)
+
+    def test_string_seconds(self):
+        assert normalize_date(str(self.TS_SEC)) == utc(2024, 6, 1)
+
+    def test_string_milliseconds(self):
+        assert normalize_date(str(self.TS_MS)) == utc(2024, 6, 1)
+
+    def test_negative_timestamp_returns_none(self):
+        assert normalize_date(-1) is None
+
+    def test_implausibly_far_future_returns_none(self):
+       
+        far_future = int(1_717_200_000 + 200 * 365.25 * 86400)
+        assert normalize_date(far_future) is None
+
+    def test_result_is_utc_aware(self):
+        result = normalize_date(self.TS_SEC)
+        assert result.tzinfo == timezone.utc
+
+
+
+# Locale / human-readable strings
+
+
+
+class TestLocaleStrings:
+    def test_mon_d_year_with_comma(self):
+        assert normalize_date("Jun 1, 2024") == utc(2024, 6, 1)
+
+    def test_full_month_d_year_with_comma(self):
+        assert normalize_date("June 1, 2024") == utc(2024, 6, 1)
+
+    def test_d_mon_year(self):
+        assert normalize_date("01 Jun 2024") == utc(2024, 6, 1)
+
+    def test_d_full_month_year(self):
+        assert normalize_date("01 June 2024") == utc(2024, 6, 1)
+
+    def test_full_month_d_year_no_comma(self):
+        assert normalize_date("June 1 2024") == utc(2024, 6, 1)
+
+    def test_dmy_dashes(self):
+        assert normalize_date("01-06-2024") == utc(2024, 6, 1)
+
+    def test_slash_format_rejected(self, caplog):
+       
+        result = normalize_date("06/01/2024")
+        assert result is None
+        assert "will fall back to created_at" in caplog.text
+
+    def test_result_is_utc_aware(self):
+
+        result = normalize_date("Jun 1, 2024")
+        assert result.tzinfo == timezone.utc
+
+
+
+#  datetime passthrough
+
+
+
+class TestDatetimePassthrough:
+    def test_naive_datetime_gets_utc_attached(self):
+        naive = datetime(2024, 6, 1, 12, 0, 0) 
+        result = normalize_date(naive)
+        assert result == utc(2024, 6, 1, 12)
+        assert result.tzinfo == timezone.utc
+
+    def test_offset_aware_datetime_converted_to_utc(self):
+        from datetime import timedelta as td
+        ist = timezone(td(hours=5, minutes=30))
+        aware = datetime(2024, 6, 1, 17, 30, 0, tzinfo=ist)  
+        result = normalize_date(aware)
+        assert result == utc(2024, 6, 1, 12)
+
+    def test_utc_datetime_returned_unchanged(self):
+
+        dt = utc(2024, 6, 1, 9, 0, 0)
+        assert normalize_date(dt) == dt
+
+
+
+# Relative strings
+
+
+
+class TestRelativeStrings:
+    """All relative assertions are relative to FAKE_NOW = 2024-06-15 12:00:00 UTC."""
+
+    def test_just_now(self):
+        assert normalize_date("just now") == FAKE_NOW
+
+    def test_today(self):
+        assert normalize_date("today") == FAKE_NOW
+
+    def test_yesterday(self):
+
+        from datetime import timedelta
+        assert normalize_date("yesterday") == FAKE_NOW - timedelta(days=1)
+
+    def test_n_seconds_ago(self):
+
+        from datetime import timedelta
+        assert normalize_date("30 seconds ago") == FAKE_NOW - timedelta(seconds=30)
+
+    def test_n_minutes_ago(self):
+        from datetime import timedelta
+        assert normalize_date("5 minutes ago") == FAKE_NOW - timedelta(minutes=5)
+
+    def test_n_hours_ago(self):
+
+        from datetime import timedelta
+        assert normalize_date("3 hours ago") == FAKE_NOW - timedelta(hours=3)
+
+    def test_n_days_ago(self):
+        from datetime import timedelta
+        assert normalize_date("3 days ago") == FAKE_NOW - timedelta(days=3)
+
+    def test_n_weeks_ago(self):
+
+        from datetime import timedelta
+        assert normalize_date("2 weeks ago") == FAKE_NOW - timedelta(weeks=2)
+
+    def test_n_months_ago(self):
+        
+        from datetime import timedelta
+        assert normalize_date("1 month ago") == FAKE_NOW - timedelta(days=30)
+
+    def test_singular_day(self):
+
+        from datetime import timedelta
+        assert normalize_date("1 day ago") == FAKE_NOW - timedelta(days=1)
+
+    def test_singular_hour(self):
+        from datetime import timedelta
+        assert normalize_date("1 hour ago") == FAKE_NOW - timedelta(hours=1)
+
+    def test_case_insensitive(self):
+
+        from datetime import timedelta
+        assert normalize_date("3 Days Ago") == FAKE_NOW - timedelta(days=3)
+
+    def test_unknown_relative_returns_none(self, caplog):
+
+        result = normalize_date("a while back")
+        assert result is None
+        assert "will fall back to created_at" in caplog.text
+
+
+
+# Malformed / edge-case inputs
+
+class TestMalformedInputs:
+    def test_garbage_string_returns_none(self, caplog):
+
+        result = normalize_date("not-a-date-at-all")
+        assert result is None
+        assert "will fall back to created_at" in caplog.text
+
+    def test_partial_iso_no_day(self, caplog):
+
+        result = normalize_date("2024-06")
+        assert result is None
+
+    def test_random_numbers_with_letters(self, caplog):
+        result = normalize_date("abc123")
+        assert result is None
+
+    def test_unexpected_type_returns_none(self, caplog):
+
+        result = normalize_date({"date": "2024-06-01"})  
+        assert result is None
+        assert "unexpected type" in caplog.text
+
+    def test_does_not_raise(self):
+
+        """normalize_date must never raise regardless of input."""
+        bad_inputs = [object(), [], 9999999999999999999, "∞", b"bytes"]
+        for inp in bad_inputs:
+            try:
+                normalize_date(inp) 
+            except Exception as exc:
+                pytest.fail(f"normalize_date raised for input {inp!r}: {exc}")
+
+
+
+#  Logging behaviour
+
+
+class TestLogging:
+    def test_warning_logged_for_bad_string(self, caplog):
+
+        import logging
+        with caplog.at_level(logging.WARNING, logger="date_utils"):
+            normalize_date("gibberish")
+        assert any("will fall back to created_at" in r.message for r in caplog.records)
+
+    def test_no_log_for_none(self, caplog):
+        import logging
+        
+        with caplog.at_level(logging.WARNING, logger="date_utils"):
+
+            normalize_date(None)
+        assert caplog.records == []
+
+    def test_no_log_for_empty_string(self, caplog):
+
+        import logging
+        with caplog.at_level(logging.WARNING, logger="date_utils"):
+            normalize_date("")
+        assert caplog.records == []

--- a/tests/unit/test_consumer_helpers.py
+++ b/tests/unit/test_consumer_helpers.py
@@ -12,8 +12,7 @@ import sys, os
 # Make the service module importable without installing it
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "aggregator-service"))
 
-from consumer import _dedup_key, _normalise, _parse_posted_at
-
+from consumer import _dedup_key, _normalise
 
 # ---------------------------------------------------------------------------
 # _normalise
@@ -68,44 +67,3 @@ class TestDedupKey:
     def test_key_is_deterministic_across_calls(self):
         keys = {_dedup_key("Cred", "Go Engineer") for _ in range(10)}
         assert len(keys) == 1
-
-
-# ---------------------------------------------------------------------------
-# _parse_posted_at
-# ---------------------------------------------------------------------------
-
-class TestParsePostedAt:
-    def test_none_returns_none(self):
-        assert _parse_posted_at(None) is None
-
-    def test_empty_string_returns_none(self):
-        assert _parse_posted_at("") is None
-
-    def test_iso_date_only(self):
-        dt = _parse_posted_at("2024-03-15")
-        assert dt is not None
-        assert dt.year == 2024
-        assert dt.month == 3
-        assert dt.day == 15
-
-    def test_iso_datetime_without_tz(self):
-        dt = _parse_posted_at("2024-03-15T10:30:00")
-        assert dt is not None
-        assert dt.tzinfo == timezone.utc
-
-    def test_iso_datetime_with_z(self):
-        dt = _parse_posted_at("2024-03-15T10:30:00Z")
-        assert dt is not None
-        assert dt.tzinfo == timezone.utc
-
-    def test_iso_with_offset(self):
-        dt = _parse_posted_at("2024-03-15T10:30:00+05:30")
-        assert dt is not None
-
-    def test_garbage_returns_none(self):
-        result = _parse_posted_at("not-a-date-at-all")
-        assert result is None
-
-    def test_partial_garbage_returns_none(self):
-        result = _parse_posted_at("15/03/2024")
-        assert result is None

--- a/tests/unit/test_date_utils.py
+++ b/tests/unit/test_date_utils.py
@@ -1,19 +1,22 @@
 """
 pytest suite for normalize_date().
-
 Run from repo root:
-    pytest aggregator/utils/test_date_utils.py -v
+    pytest tests/unit/test_date_utils.py -v
 
-All tests are pure-stdlib — no extra dependencies beyond pytest itself.
-The _utcnow helper in date_utils is monkeypatched.
 """
 
 from __future__ import annotations
-
+import os
+import sys
 from datetime import datetime, timezone
 from unittest.mock import patch
 
 import pytest
+
+sys.path.insert(
+    0,
+    os.path.join(os.path.dirname(__file__), "..", "..", "aggregator-service")
+)
 
 from utils.date_utils import normalize_date
 


### PR DESCRIPTION
## Related Issue

Closes #10 

## Description

This PR introduces a centralized `normalize_date()` utility for the aggregator ingestion pipeline to normalize all incoming `posted_at` values consistently before storage.

The implementation replaces the existing `_parse_posted_at()` flow in `consumer.py` and adds support for multiple input formats including:

* ISO 8601 strings
* Unix timestamps (seconds and milliseconds)
* Relative date strings such as `3 days ago`
* Common explicit date formats
* Empty/null values

All parsed timestamps are normalized into timezone-aware UTC datetimes for consistency with the existing `TIMESTAMPTZ` storage flow. The parser intentionally avoids overly permissive parsing behavior by rejecting ambiguous slash-separated formats to keep normalization deterministic. When parsing fails, the ingestion flow continues safely by falling back to `created_at`, while also logging warnings for malformed values without interrupting aggregation.

This PR also adds comprehensive unit tests covering:

* ISO parsing
* Unix timestamps
* Relative date handling
* Malformed inputs
* UTC normalization
* Logging behavior
* Fallback-related scenarios

Additionally, the implementation was validated through live Redis → Aggregator → PostgreSQL ingestion testing to confirm correct database updates and fallback behavior.
