### PR TITLE
feat: Add Weekly job digest email

### DIFF
--- a/email-generator-service/generator_digest.py
+++ b/email-generator-service/generator_digest.py
@@ -1,0 +1,120 @@
+"""
+generator_digest.py — Weekly digest email generator.
+ 
+Kept intentionally separate from generator.py so the existing
+single-email generation pipeline is not touched at all.
+ 
+Pipeline:
+  1. Receive a flat list of job dicts from the caller.
+  2. Filter out jobs older than MAX_AGE_DAYS (staleness guard).
+  3. Group the remaining jobs by their 'source' field.
+  4. Render digest.j2 with the grouped data.
+  5. Return (subject, body) strings — identical contract to generator.generate_email().
+ 
+The caller (main.py /digest endpoint) handles SMTP sending
+via the existing mailer.send_email(), so no SMTP logic lives here.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone, timedelta
+from typing import Any
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+logger = logging.getLogger(__name__)
+_TEMPLATE_DIR = Path(__file__).parent / "templates"
+
+_jinja_env = Environment(
+    loader=FileSystemLoader(str(_TEMPLATE_DIR)),
+    autoescape=select_autoescape(disabled_extensions=("j2",)),
+    trim_blocks=True,
+    lstrip_blocks=True,
+)
+MAX_AGE_DAYS = 7
+
+
+def generate_digest(
+    *,
+    jobs: list[dict[str, Any]],
+    your_name: str,
+    week_label: str,
+) -> tuple[str, str]:
+    if jobs is None:
+        raise ValueError("jobs must be a list, got None")
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=MAX_AGE_DAYS)
+    recent_jobs: list[dict[str, Any]] = []
+
+    for job in jobs:
+        posted_raw = job.get("posted_at")
+
+        if posted_raw is None:
+            recent_jobs.append(job)
+            continue
+
+        try:
+            posted_dt = datetime.fromisoformat(str(posted_raw))
+            if posted_dt.tzinfo is None:
+                posted_dt = posted_dt.replace(tzinfo=timezone.utc)
+
+            if posted_dt >= cutoff:
+                recent_jobs.append(job)
+            else:
+                logger.debug(
+                    "Digest: skipping stale job %s @ %s (posted %s)",
+                    job.get("role"),
+                    job.get("company"),
+                    posted_raw,
+                )
+        except (ValueError, TypeError) as exc:
+            logger.warning(
+                "Digest: could not parse posted_at=%r for %s @ %s — including anyway: %s",
+                posted_raw,
+                job.get("role"),
+                job.get("company"),
+                exc,
+            )
+            recent_jobs.append(job)
+
+    logger.info(
+        "Digest: %d total jobs → %d fresh (cutoff: %s)",
+        len(jobs),
+        len(recent_jobs),
+        cutoff.isoformat(),
+    )
+
+    jobs_by_source: dict[str, list[dict[str, Any]]] = {}
+    for job in recent_jobs:
+        source = job.get("source") or "unknown"
+        jobs_by_source.setdefault(source, []).append(job)
+
+    context: dict[str, Any] = {
+        "your_name": your_name,
+        "job_count": len(recent_jobs),
+        "week_label": week_label,
+        "jobs_by_source": jobs_by_source,
+        "sources_count": len(jobs_by_source),
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
+    }
+
+    template = _jinja_env.get_template("digest.j2")
+    rendered_text = template.render(**context)
+
+    lines = rendered_text.strip().splitlines()
+    subject = ""
+    body_lines: list[str] = []
+
+    for i, line in enumerate(lines):
+        if i == 0 and line.lower().startswith("subject:"):
+            subject = line[len("subject:") :].strip()
+        elif i == 1:
+            continue
+        else:
+            body_lines.append(line)
+
+    body = "\n".join(body_lines).strip()
+    logger.info("Digest email rendered — subject: %s", subject)
+
+    return subject, body

--- a/email-generator-service/main.py
+++ b/email-generator-service/main.py
@@ -24,6 +24,7 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
 import generator
+import generator_digest
 import mailer
 import storage
 
@@ -100,6 +101,35 @@ class EmailOut(BaseModel):
         d["generated_at"] = d["generated_at"].isoformat()
         d["sent_at"] = d["sent_at"].isoformat() if d.get("sent_at") else None
         return cls(**d)
+
+
+class DigestRequest(BaseModel):
+    """
+    Payload sent by the scheduler to trigger a weekly digest email.
+
+    Fields
+    ------
+    jobs : list[dict]
+        Raw job records from GET /api/jobs — the email-generator does its
+        own staleness filtering here, keeping the scheduler orchestration-light.
+
+    recipient_email : str
+        Who receives the digest. Defaults to GMAIL_ADDRESS env var if omitted.
+        This lets the system self-send as a personal digest without extra config.
+
+    your_name : str
+        The user's display name for the greeting line.
+        Defaults to the YOUR_NAME env var.
+
+    week_label : str
+        Human-readable date range, e.g. "12–18 May 2026".
+        The scheduler computes and passes this so the template doesn't need
+        datetime logic.
+    """
+    jobs: List[dict]
+    recipient_email: Optional[str] = None
+    your_name: str = ""
+    week_label: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -221,3 +251,76 @@ async def send_email_endpoint(email_id: UUID):
 
     row = await storage.mark_sent(pool, email_id)
     return EmailOut.from_record(row)
+
+
+@app.post("/digest", tags=["emails"])
+async def send_digest(req: DigestRequest):
+    """
+    Generate and immediately send a weekly job digest email.
+
+    Steps performed here:
+      1. Resolve recipient address (request body → GMAIL_ADDRESS env var).
+      2. Resolve sender name (request body → YOUR_NAME env var).
+      3. Compute a week_label if the caller didn't provide one.
+      4. Call generator_digest.generate_digest() to filter, group, and render.
+      5. Send the rendered email via the existing mailer.send_email().
+      6. Return a summary of what was sent.
+
+    This endpoint intentionally does NOT store the digest in the emails table.
+    The digest is a notification, not an outreach draft that needs tracking.
+    If the owner later wants storage, a separate PR can add it.
+    """
+
+    recipient = (
+        req.recipient_email
+        or os.environ.get("DIGEST_RECIPIENT_EMAIL", "").strip()
+        or os.environ.get("GMAIL_ADDRESS", "").strip()
+    )
+
+    if not recipient:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "No recipient address. Set DIGEST_RECIPIENT_EMAIL or GMAIL_ADDRESS "
+                "in environment, or pass recipient_email in the request body."
+            ),
+        )
+
+    your_name = req.your_name or os.environ.get("YOUR_NAME", "Applicant").strip()
+
+    if req.week_label:
+        week_label = req.week_label
+    else:
+        from datetime import timedelta, timezone as _tz
+        today = datetime.now(_tz.utc)
+        week_start = today - timedelta(days=today.weekday())
+        week_end = week_start + timedelta(days=6)
+        week_label = f"{week_start.strftime('%d %b')}–{week_end.strftime('%d %b %Y')}"
+
+    try:
+        subject, body = generator_digest.generate_digest(
+            jobs=req.jobs,
+            your_name=your_name,
+            week_label=week_label,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    try:
+        await mailer.send_email(
+            to_address=recipient,
+            subject=subject,
+            body=body,
+        )
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail=str(exc))
+    except Exception as exc:
+        logger.exception("Digest email send failed: %s", exc)
+        raise HTTPException(status_code=502, detail=f"SMTP error: {exc}")
+
+    return {
+        "sent": True,
+        "recipient": recipient,
+        "subject": subject,
+        "job_count": len(req.jobs),
+    }

--- a/email-generator-service/templates/digest.j2
+++ b/email-generator-service/templates/digest.j2
@@ -1,0 +1,32 @@
+Subject: Your weekly job digest — {{ job_count }} new role{% if job_count != 1 %}s{% endif %} ({{ week_label }})
+
+Hi {{ your_name }},
+
+Here is your weekly summary of new engineering roles that match your profile.
+
+{% if jobs_by_source %}
+{% for source, jobs in jobs_by_source.items() %}
+── {{ source | upper }} ({{ jobs | length }} role{% if jobs | length != 1 %}s{% endif %}) ──────────────────────
+
+{% for job in jobs %}
+  {{ loop.index }}. {{ job.company }} — {{ job.role }}
+     {% if job.location %}📍 {{ job.location }}{% endif %}{% if job.stack %}  🛠  {{ job.stack | join(", ") }}{% endif %}
+
+     {% if job.url %}🔗 {{ job.url }}{% endif %}
+
+{% endfor %}
+{% endfor %}
+{% else %}
+No new roles found this week. The pipeline will check again next Sunday.
+{% endif %}
+
+──────────────────────────────────────────────────
+Roles shown: {{ job_count }}  |  Sources: {{ sources_count }}
+Generated: {{ generated_at }}
+──────────────────────────────────────────────────
+
+To apply to any of these, open your dashboard at http://localhost:8080 and
+click "Draft" on a job card to generate a personalized cold email.
+
+Best,
+Arachnode

--- a/gateway/main.py
+++ b/gateway/main.py
@@ -189,6 +189,11 @@ async def proxy_generate(request: Request):
     return await proxy.proxy_request(request, f"{proxy.EMAIL_GEN_URL}/generate")
 
 
+@app.api_route("/api/digest", methods=["POST"], tags=["proxy"])
+async def proxy_digest(request: Request):
+    return await proxy.proxy_request(request, f"{proxy.EMAIL_GEN_URL}/digest")
+
+
 # ---------------------------------------------------------------------------
 # Composite endpoint — POST /api/workflow/apply
 # ---------------------------------------------------------------------------

--- a/scheduler/README.md
+++ b/scheduler/README.md
@@ -175,3 +175,52 @@ SIGTERM received
 
 Docker sends `SIGTERM` on `docker compose stop` / `docker compose down`,
 so no data will be lost mid-cycle.
+
+---
+
+## Weekly Digest
+
+Every **Sunday at 09:00 UTC**, the scheduler runs a digest cycle that:
+
+1. Fetches all `status=new` jobs from the aggregator (up to 100, sorted newest-first).
+2. POSTs the raw list to the email-generator's `/digest` endpoint.
+3. The email-generator filters out jobs older than 7 days, groups the remainder
+   by source (Remotive, Naukri, LinkedIn, etc.), renders them into a digest email,
+   and sends it via Gmail SMTP.
+
+---
+
+### New environment variable
+
+| Variable | Default | Description |
+|---|---|---|
+| `DIGEST_RECIPIENT_EMAIL` | `GMAIL_ADDRESS` | Who receives the weekly digest. Defaults to self-send if not set. |
+
+---
+
+### Triggering the digest manually (without waiting for Sunday)
+
+```bash
+# Via docker-compose
+docker compose run --rm \
+  -e MANUAL_TASK=digest \
+  -e GATEWAY_URL=http://gateway:8080 \
+  scheduler
+
+# Via local Python (with venv activated)
+MANUAL_TASK=digest python main.py
+```
+
+This runs the digest cycle immediately and exits, identical to how
+`MANUAL_TASK=scrape` works for the scrape cycle.
+
+---
+
+### Updated schedule summary
+
+| Cycle | Trigger | Offset | What happens |
+|---|---|---|---|
+| **Scrape** | Every 8h (starts on startup) | — | Scrapes all platforms |
+| **Discover** | Every 24h | +4h from startup | Finds contacts for new jobs |
+| **Draft** | Every 24h | +8h from startup | Pre-generates cold email drafts |
+| **Digest** | Every Sunday at 09:00 UTC | — | Sends a weekly summary email |

--- a/scheduler/main.py
+++ b/scheduler/main.py
@@ -150,6 +150,18 @@ def build_scheduler() -> BackgroundScheduler:
         start_date=_offset_start(hours=8),
     )
 
+    # ── Job 4: Weekly digest every Sunday at 09:00 UTC ────────────────────
+    scheduler.add_job(
+        func=lambda: _run(tasks.run_digest_cycle, "digest"),
+        trigger="cron",
+        day_of_week="sun",
+        hour=9,
+        minute=0,
+        timezone="UTC",
+        id="digest",
+        name="Weekly job digest email",
+    )
+
     return scheduler
 
 
@@ -166,7 +178,7 @@ def _offset_start(hours: int) -> datetime:
 def _maybe_manual_run() -> None:
     """
     If MANUAL_TASK env var is set, run that task immediately and exit.
-    Valid values: scrape | discover | draft | all
+    Valid values: scrape | discover | draft | digest | all
     """
     task_name = os.environ.get("MANUAL_TASK", "").strip().lower()
     if not task_name:
@@ -177,6 +189,7 @@ def _maybe_manual_run() -> None:
         "scrape":   tasks.run_scrape_cycle,
         "discover": tasks.run_discover_cycle,
         "draft":    tasks.run_draft_cycle,
+        "digest":   tasks.run_digest_cycle,
     }
 
     if task_name == "all":

--- a/scheduler/tasks.py
+++ b/scheduler/tasks.py
@@ -18,6 +18,7 @@ import json
 import os
 import subprocess
 import time
+from datetime import timedelta
 from typing import Any
 
 import httpx
@@ -251,3 +252,74 @@ def run_draft_cycle() -> None:
 
     _summary["emails_drafted"] += drafted
     log.info("Draft cycle complete", drafted=drafted)
+
+
+# ---------------------------------------------------------------------------
+# Task 4 — Weekly digest cycle  (every Sunday at 09:00 UTC)
+# ---------------------------------------------------------------------------
+
+def run_digest_cycle() -> None:
+    """
+    Fetch all new jobs from the past 7 days and POST them to the email-generator
+    service's /digest endpoint, which filters for freshness, groups by source,
+    renders the digest template, and sends the email via Gmail SMTP.
+    """
+
+    log.info("Digest cycle starting")
+
+    from datetime import datetime, timezone
+    today = datetime.now(timezone.utc)
+    week_start = today - timedelta(days=today.weekday())
+    week_end = week_start + timedelta(days=6)
+    week_label = f"{week_start.strftime('%d %b')}–{week_end.strftime('%d %b %Y')}"
+
+    try:
+        with httpx.Client(timeout=_HTTP_TIMEOUT) as c:
+            r = c.get(
+                f"{_gw()}/api/jobs",
+                params={
+                    "status": "new",
+                    "limit": 100,
+                    "sort": "latest",
+                },
+            )
+            r.raise_for_status()
+            jobs = r.json()
+
+    except Exception as exc:
+        _record_error("digest_fetch_jobs", str(exc))
+        log.error("Digest cycle aborted — could not fetch jobs", error=str(exc))
+        return
+
+    if not jobs:
+        log.info("Digest cycle: no new jobs found — skipping send")
+        return
+
+    log.info("Digest cycle: fetched %d new jobs", len(jobs))
+
+    try:
+        with httpx.Client(timeout=httpx.Timeout(90.0, connect=10.0)) as c:
+            r = c.post(
+                f"{_gw()}/api/digest",
+                json={
+                    "jobs": jobs,
+                    "week_label": week_label,
+                },
+            )
+            r.raise_for_status()
+            result = r.json()
+
+    except Exception as exc:
+        _record_error("digest_send", str(exc))
+        log.error("Digest cycle: email send failed", error=str(exc))
+        return
+
+    log.info(
+        "Digest cycle complete",
+        sent=result.get("sent"),
+        recipient=result.get("recipient"),
+        job_count=result.get("job_count"),
+        subject=result.get("subject"),
+    )
+
+    _summary["digest_sent"] = result.get("job_count", 0)


### PR DESCRIPTION
Closes #11

## Summary
Implements a weekly job digest that emails a grouped summary of new 
engineering roles every Sunday at 09:00 UTC. Scheduler-driven, reuses 
the existing Gmail SMTP pipeline, zero new dependencies.

## Changes

- `email-generator-service/templates/digest.j2` — new multi-job Jinja2 
  template grouping roles by source. Existing single-job templates untouched.
  Added because existing templates are per-job; a digest requires iterating 
  over a grouped list — structurally different.

- `email-generator-service/generator_digest.py` — new module with 
  `generate_digest()`. Handles staleness filtering (7-day cutoff on 
  `posted_at`) and grouping by source. Lives here, not in the scheduler, 
  keeping scheduler orchestration-light per owner feedback.

- `email-generator-service/main.py` — added `DigestRequest` model and 
  `POST /digest` endpoint. No existing endpoints modified.

- `scheduler/tasks.py` — added `run_digest_cycle()` at bottom of file. 
  Fetches jobs, forwards raw list to `/api/digest`. No grouping or filtering 
  in the scheduler.

- `scheduler/main.py` — registered 4th APScheduler cron job (Sunday 09:00 
  UTC). Added `digest` to `MANUAL_TASK` dispatch dict.

- `gateway/main.py` — added `POST /api/digest` proxy route. One new route, 
  nothing else changed.

- `scheduler/README.md` — documented new schedule entry, 
  `DIGEST_RECIPIENT_EMAIL` env var, and `MANUAL_TASK=digest`.

## How stale/duplicate jobs are excluded
- Duplicates: handled at ingestion by the aggregator (Redis dedup key + 
  `ON CONFLICT DO NOTHING`). Not reimplemented here.
- Staleness: `generator_digest.py` drops jobs where `posted_at` is older 
  than 7 days before rendering. Runs in the email-generator, not the scheduler.

## New environment variable
| Variable | Default | Description |
|---|---|---|
| `DIGEST_RECIPIENT_EMAIL` | `GMAIL_ADDRESS` | Digest recipient. Defaults to self-send. |

## No new dependencies
`jinja2`, `httpx`, `smtplib` already present in `requirements.txt`.
No new database tables or Redis streams.

## Testing Evidence

**Scheduler logs — task execution + dispatch confirmation**
<img width="1132" height="236" alt="image" src="https://github.com/user-attachments/assets/11700ac9-ac1f-494c-bff2-9e7227012fd5" />
**Gmail — received digest email**
<img width="1731" height="708" alt="Screenshot 2026-05-21 115611" src="https://github.com/user-attachments/assets/9b824a62-0939-4e81-810a-84fa5cd643c7" />

https://github.com/user-attachments/assets/b2f86eb2-b8e9-48da-8d1e-0530887e8659


