### PR TITLE
fix: prevent duplicate job URLs by adding unique index

### DIFF
--- a/aggregator-service/db.py
+++ b/aggregator-service/db.py
@@ -81,6 +81,11 @@ CREATE INDEX IF NOT EXISTS idx_jobs_posted_at
 -- BTREE index for filtering by status
 CREATE INDEX IF NOT EXISTS idx_jobs_status
     ON jobs (status);
+    
+-- Prevent duplicate job URLs by enforcing uniqueness
+CREATE UNIQUE INDEX IF NOT EXISTS idx_jobs_url_unique
+ON jobs(url)
+WHERE url IS NOT NULL;    
 """
 
 


### PR DESCRIPTION
Added a partial unique index on the url column to prevent duplicate job entries. This ensures ON CONFLICT DO NOTHING works correctly.