### PR TITLE
docs: fix incorrect clone URL and project directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ Note: If you do not install Ollama, the email generator gracefully degrades to s
 
 1. Clone the repository and navigate into the root directory.
 ```bash
-git clone https://github.com/vaibhav-sharma/jobCrawler.git
-cd jobCrawler
+git clone https://github.com/sharmavaibhav31/arachnode.git
+cd arachnode
 ```
 
 2. Copy the example environment file and fill in the required variables.

--- a/tests/integration/test_aggregator_export.py
+++ b/tests/integration/test_aggregator_export.py
@@ -10,13 +10,13 @@ Run with:
 
 Requires: pip install pytest pytest-asyncio testcontainers asyncpg httpx
 """
-import os
+import asyncio
 import csv
 import io
 import pytest
 import asyncpg
 import sys
-import asyncio
+import os
 from httpx import AsyncClient
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "aggregator-service"))

--- a/tests/integration/test_aggregator_export.py
+++ b/tests/integration/test_aggregator_export.py
@@ -10,13 +10,13 @@ Run with:
 
 Requires: pip install pytest pytest-asyncio testcontainers asyncpg httpx
 """
-
+import os
 import csv
 import io
 import pytest
 import asyncpg
 import sys
-import os
+import asyncio
 from httpx import AsyncClient
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "aggregator-service"))


### PR DESCRIPTION
## Description
Fixed outdated repository clone URL and corrected project directory references in the README installation instructions.

## Changes Made
- Updated old `jobCrawler` repository URL
- Corrected project directory name to `arachnode`

## Issue
Closes #82