### PR TITLE
fix: align healthcheck ports and docs to actual service port 8000

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The system uses an event-driven microservice architecture with Python across the
 ┌──────────▼──────────┐                           ┌──────▼────────▼────────┐
 │                     │       Jobs via POST       │                        │
 │  Platform Scraper   ├──────────────────────────►│   Aggregator Service   │
-│      (:8001)        │                           │        (:8000)         │
+│      (:8000)        │                           │        (:8000)         │
 └─────────────────────┘                           └──────┬─────────────────┘
                                                          │        ▲
 ┌─────────────────────┐       Jobs via Stream            │        │ Store
@@ -61,17 +61,17 @@ The system uses an event-driven microservice architecture with Python across the
 ┌─────────────────────┐                           ┌──────▼────────▼────────┐
 │                     │   Trigger via REST POST   │                        │
 │    Email Service    ◄───────────────────────────┤   Contact Discovery    │
-│       (:8003)       │                           │        (:8002)         │
+│       (:8000)       │                           │        (:8000)         │
 └─────────────────────┘                           └────────────────────────┘
 ```
 
 | Service | Language/Framework | Port | Responsibility |
 | --- | --- | --- | --- |
 | Crawler | Python / Scrapy | None | Navigates startup directories, extracts job listings, and publishes items to a Redis stream. |
-| Platform Scraper | Python / FastAPI / Playwright | 8001 | Handles on-demand JavaScript-heavy browser scraping for platforms like LinkedIn. |
+| Platform Scraper | Python / FastAPI / Playwright | 8000 | Handles on-demand JavaScript-heavy browser scraping for platforms like LinkedIn. |
 | Aggregator | Python / FastAPI / asyncpg | 8000 | Consumes the Redis stream, deduplicates entries, saves to Postgres, and serves job queries. |
-| Contact Discovery | Python / FastAPI / httpx | 8002 | Uses OSINT and GitHub APIs to uncover potential recruiter/manager emails per company. |
-| Email Generator | Python / FastAPI / Ollama | 8003 | Renders Jinja2 templates and interfaces with Ollama to draft contextual cold emails. |
+| Contact Discovery | Python / FastAPI / httpx | 8000 | Uses OSINT and GitHub APIs to uncover potential recruiter/manager emails per company. |
+| Email Generator | Python / FastAPI / Ollama | 8000 | Renders Jinja2 templates and interfaces with Ollama to draft contextual cold emails. |
 | Gateway | Python / FastAPI / Vanilla JS | 8080 | Proxies frontend requests, composes complex workflows, and serves the static dashboard. |
 | Scheduler | Python / APScheduler | None | Periodically triggers crawlers, contact discovery, and automated email drafting. |
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,9 @@
 #   postgres     — shared database
 #   crawler      — Scrapy job crawler (one-shot)
 #   aggregator   — FastAPI stream consumer + jobs REST API  (:8000)
-#   scraper      — Platform scraper (Naukri/LinkedIn/Internshala)  (:8001)
-#   contact      — Contact discovery pipeline  (:8002)
-#   email-gen    — Cold email generator  (:8003)
+#   scraper      — Platform scraper (Naukri/LinkedIn/Internshala)  (:8000)
+#   contact      — Contact discovery pipeline  (:8000)
+#   email-gen    — Cold email generator  (:8000)
 #   gateway      — API gateway + dashboard  (:8080)
 #   scheduler    — APScheduler pipeline automation (background)
 # ─────────────────────────────────────────────────────────────────────────────

--- a/gateway/proxy.py
+++ b/gateway/proxy.py
@@ -25,9 +25,9 @@ def _url(env_var: str, default: str) -> str:
     return os.environ.get(env_var, default).rstrip("/")
 
 AGGREGATOR_URL = _url("AGGREGATOR_URL", "http://aggregator:8000")
-SCRAPER_URL    = _url("SCRAPER_URL",    "http://scraper:8001")
-CONTACT_URL    = _url("CONTACT_URL",    "http://contact:8002")
-EMAIL_GEN_URL  = _url("EMAIL_GEN_URL",  "http://email-gen:8003")
+SCRAPER_URL    = _url("SCRAPER_URL",    "http://scraper:8000")
+CONTACT_URL    = _url("CONTACT_URL",    "http://contact:8000")
+EMAIL_GEN_URL  = _url("EMAIL_GEN_URL",  "http://email-gen:8000")
 
 _TIMEOUT = httpx.Timeout(30.0, connect=5.0)
 


### PR DESCRIPTION
Closes #46

# Changes

- Updated `docker-compose.yml` header comments to show correct internal port `:8000` for scraper, contact, and email-gen services (previously listed as `:8001`, `:8002`, `:8003`)
- Fixed `gateway/proxy.py` default fallback URLs for `SCRAPER_URL`, `CONTACT_URL`, and `EMAIL_GEN_URL` from ports `8001`/`8002`/`8003` to `8000`, matching what each service's Dockerfile actually EXPOSEs and uvicorn listens on
- Corrected `README.md` architecture diagram port labels and service port table to reflect that all four FastAPI services (aggregator, scraper, contact-discovery, email-generator) run on port `8000` internally

# Testing

- Verified all three service Dockerfiles confirm `EXPOSE 8000` and `uvicorn ... --port 8000`
- Confirmed `docker-compose.yml` gateway environment already passes `http://<service>:8000` URLs, validating that port `8000` is the correct internal port
- Healthcheck `curl` commands in `docker-compose.yml` (lines 102, 121, 144) already target `localhost:8000/health`, which is now consistent with all documentation
