### PR TITLE
[ML] feat(aggregator): added SBERT-based semantic job matcher with resume ranking

### DIFF
--- a/aggregator-service/README.md
+++ b/aggregator-service/README.md
@@ -28,6 +28,7 @@ aggregator-service/
 ├── main.py          # FastAPI app, lifespan, endpoints
 ├── db.py            # asyncpg pool, schema init, query helpers
 ├── consumer.py      # Redis Stream consumer loop
+├── matcher.py       # Optional SBERT-based semantic job ranking
 ├── models.py        # Pydantic response schemas
 ├── requirements.txt
 ├── Dockerfile
@@ -48,6 +49,7 @@ aggregator-service/
 | `POSTGRES_USER` | `jobuser` | (docker-compose only) |
 | `POSTGRES_PASSWORD` | `jobpass` | (docker-compose only) |
 | `POSTGRES_DB` | `jobsdb` | (docker-compose only) |
+| `MATCHER_CACHE_DIR` | `/tmp/arachnode_cache` | Directory for resume embedding cache |
 
 ---
 
@@ -108,6 +110,7 @@ curl http://localhost:8000/health
 | `status` | string | — | `new` \| `applied` \| `ignored` |
 | `sort` | string | `latest` | `latest` or `oldest` (by `posted_at`) |
 | `limit` | int | `50` | Max results (1–500) |
+| `resume` | string | — | Resume text; when provided, jobs are ranked by semantic similarity instead of date |
 
 ```bash
 # All new jobs
@@ -118,10 +121,13 @@ curl "http://localhost:8000/jobs?role=backend&stack=Python&sort=oldest&limit=20"
 
 # Jobs that require both FastAPI and PostgreSQL
 curl "http://localhost:8000/jobs?stack=FastAPI,PostgreSQL"
+
+# Jobs ranked by match to a resume
+curl "http://localhost:8000/jobs?resume=NLP%20engineer%20with%20HuggingFace%20Transformers%20and%20PyTorch"
 ```
 
 <details>
-<summary>Example response</summary>
+<summary>Example response — without resume (existing behaviour)</summary>
 
 ```json
 [
@@ -136,10 +142,53 @@ curl "http://localhost:8000/jobs?stack=FastAPI,PostgreSQL"
     "location": "Remote",
     "posted_at": "2026-03-18T10:00:00Z",
     "status": "new",
-    "created_at": "2026-03-19T04:00:00Z"
+    "created_at": "2026-03-19T04:00:00Z",
+    "match_score": null,
+    "match_tier": null
   }
 ]
 ```
+</details>
+
+<details>
+<summary>Example response — with resume (semantic ranking)</summary>
+
+```json
+[
+  {
+    "id": "xyz789",
+    "company": "Sarvam AI",
+    "role": "NLP Engineer - Indic Languages",
+    "source": "remotive",
+    "url": "https://remotive.com/jobs/456",
+    "stack": ["PyTorch", "Transformers"],
+    "product": "Language Models",
+    "location": "Remote",
+    "posted_at": "2026-03-18T10:00:00Z",
+    "status": "new",
+    "created_at": "2026-03-19T04:00:00Z",
+    "match_score": 0.6842,
+    "match_tier": "strong"
+  },
+  {
+    "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    "company": "Acme Corp",
+    "role": "Senior Backend Engineer",
+    "source": "remotive",
+    "url": "https://remotive.com/jobs/123",
+    "stack": ["Python", "FastAPI", "PostgreSQL"],
+    "product": "Platform",
+    "location": "Remote",
+    "posted_at": "2026-03-18T10:00:00Z",
+    "status": "new",
+    "created_at": "2026-03-19T04:00:00Z",
+    "match_score": 0.3201,
+    "match_tier": "weak"
+  }
+]
+```
+
+Jobs are sorted by `match_score` descending. `match_tier` is one of `strong` (≥ 0.55), `moderate` (0.40–0.54), or `weak` (< 0.40).
 </details>
 
 ---
@@ -192,6 +241,91 @@ curl http://localhost:8000/stats
   }
 }
 ```
+
+---
+
+## Semantic Job Matching
+
+When a `resume` query param is passed to `GET /jobs`, the aggregator ranks jobs by semantic similarity to the resume using Sentence-BERT instead of returning them by date. When no resume is passed, behaviour is identical to before.
+
+### How it works
+
+```
+resume text (query param)
+        │
+        ▼
+resume embedding: disk cache check
+        │ hit: load pickle       miss: encode + cache to disk
+        ▼
+JD text built per job: role + company + stack + product
+        │
+        ▼
+all JDs batch-encoded in one model.encode() call (batch_size=32)
+        │
+        ▼
+cosine similarity computed per job
+        │
+        ▼
+jobs sorted descending by match_score, match_tier attached
+```
+
+### Model — all-MiniLM-L6-v2
+
+| Property | Detail |
+|---|---|
+| Size | ~80MB |
+| GPU required | No |
+| Loading strategy | Lazy — loads on first request that includes a resume param |
+| Strength | Captures semantic meaning, not just keyword overlap |
+
+**Why SBERT over TF-IDF?** TF-IDF only matches on shared words. A resume mentioning "HuggingFace Transformers and PyTorch" would score zero against "NLP Engineer — Indic Languages" because there is no word overlap, even though it is the correct top match. SBERT encodes meaning and ranks it correctly.
+
+### Installation
+
+Semantic matching requires one additional package not in the base `requirements.txt`:
+
+```bash
+pip install sentence-transformers
+```
+
+If `sentence-transformers` is not installed, the matcher silently disables itself and `GET /jobs` continues to work normally — jobs are returned unranked and no error is thrown.
+
+### Caching
+
+Resume embeddings are cached to disk so the same resume text is never encoded twice, even across app restarts.
+
+| Property | Detail |
+|---|---|
+| Location | `/tmp/arachnode_cache` (override with `MATCHER_CACHE_DIR`) |
+| Key | MD5 hash of resume text |
+| Format | Pickle — `resume_<hash>.pkl` |
+| Invalidation | Different resume text → different hash → new file. No TTL. |
+
+Only resume embeddings are cached. JD embeddings are recomputed per request via batch encoding.
+
+To clear the cache manually:
+```bash
+rm -rf /tmp/arachnode_cache
+```
+
+### Fallback behaviour
+
+| Condition | Result |
+|---|---|
+| No `resume` param | Date-ordered response, `match_score`/`match_tier` null |
+| Empty or whitespace resume | Jobs returned unranked, warning logged |
+| `sentence-transformers` not installed | Jobs returned unranked, warning logged |
+
+The endpoint never returns a 500 due to matcher failure.
+
+### Running matcher tests
+
+```bash
+cd aggregator-service
+python test_matcher_final.py
+```
+
+Covers: ranking output, cache hit behaviour, empty resume handling, top match accuracy, worst match accuracy.
 
 ---
 

--- a/aggregator-service/main.py
+++ b/aggregator-service/main.py
@@ -28,6 +28,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 import db as database
 import consumer as stream_consumer
 from models import JobOut, StatusUpdate, StatsOut
+from matcher import rank_jobs
 
 logging.basicConfig(
     level=logging.INFO,
@@ -111,6 +112,7 @@ async def list_jobs(
     status: Optional[str] = Query(None, description="Filter by status: new | applied | ignored"),
     sort: str = Query("latest", description="Sort order: latest | oldest"),
     limit: int = Query(50, ge=1, le=500, description="Max results to return"),
+    resume: Optional[str] = Query(None, description="Paste resume text for semantic ranking"),
 ):
     if sort not in ("latest", "oldest"):
         raise HTTPException(status_code=400, detail="sort must be 'latest' or 'oldest'")
@@ -128,7 +130,11 @@ async def list_jobs(
         sort=sort,
         limit=limit,
     )
-    return [JobOut(**_record_to_dict(r)) for r in rows]
+    jobs = [_record_to_dict(r) for r in rows]
+    if resume:
+        jobs = rank_jobs(jobs, resume)
+    return [JobOut(**job) for job in jobs]
+    
 
 
 @app.get("/jobs/export", tags=["jobs"])
@@ -234,3 +240,4 @@ async def get_stats():
     pool = await database.get_pool()
     stats = await database.get_stats(pool)
     return StatsOut(**stats)
+

--- a/aggregator-service/matcher.py
+++ b/aggregator-service/matcher.py
@@ -1,0 +1,177 @@
+# matcher.py
+# Yeh module completely optional hai — agar resume nahi diya toh
+# yeh code kabhi bhi main flow mein nahi aayega
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import pickle
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+# lazy loading 
+_model = None
+
+# Resume embeddings cache — disk pe save karenge
+# Taaki app restart pe bhi recompute na ho
+CACHE_DIR = os.getenv("MATCHER_CACHE_DIR", "/tmp/arachnode_cache")
+
+
+def _get_model():
+    """
+    model loads only when called
+    """
+    global _model
+    if _model is None:
+        try:
+            # sentence-transformers import try karo
+            # agar installed nahi hai toh gracefully fail hoga
+            from sentence_transformers import SentenceTransformer
+            logger.info("Loading SBERT model — MiniLM (lightweight, ~80MB)")
+            _model = SentenceTransformer("all-MiniLM-L6-v2")
+            logger.info("Model loaded successfully")
+        except ImportError:
+            # sentence-transformers installed nahi — matching disabled
+            logger.warning("sentence-transformers not installed. Matching disabled.")
+            return None
+    return _model
+
+
+def _build_jd_text(job: Dict[str, Any]) -> str:
+    """
+    Job dict se ek clean text string banao jo SBERT encode karega.
+    
+    models.py se hume pata hai:
+    - role      : str
+    - company   : str  
+    - stack     : List[str]  <-- list hai, string nahi, isliye join karna padega
+    - product   : Optional[str]
+    
+    description field EXISTS NAHI DB mein isliye use nahi kar sakte.
+    """
+    parts = []
+    
+    if job.get("role"):
+        parts.append(job["role"])
+    
+    if job.get("company"):
+        parts.append(job["company"])
+    
+    if job.get("stack"):
+        parts.append(" ".join(job["stack"]))
+    
+    if job.get("product"):
+        parts.append(job["product"])
+    
+    
+    return " ".join(parts)
+
+
+def _get_resume_cache_path(resume_text: str) -> str:
+    """
+    Resume text ka MD5 hash  & cache file  path return .
+    Same resume = same hash = same cached embedding, recompution no .
+    """
+    os.makedirs(CACHE_DIR, exist_ok=True)
+    resume_hash = hashlib.md5(resume_text.encode()).hexdigest()
+    return os.path.join(CACHE_DIR, f"resume_{resume_hash}.pkl")
+
+
+def _get_resume_embedding(model, resume_text: str) -> np.ndarray:
+    """
+    Resume embedding lo —  cache check , not found then compute .
+    """
+    cache_path = _get_resume_cache_path(resume_text)
+    
+    # Cache ?
+    if os.path.exists(cache_path):
+        logger.info("Resume embedding found in cache — skipping recompute")
+        with open(cache_path, "rb") as f:
+            return pickle.load(f)
+    
+    # Not there
+    logger.info("Computing resume embedding (first time)...")
+    embedding = model.encode(resume_text, convert_to_numpy=True)
+    
+    with open(cache_path, "wb") as f:
+        pickle.dump(embedding, f)
+    
+    logger.info("Resume embedding cached to disk")
+    return embedding
+
+
+def _cosine_similarity(vec_a: np.ndarray, vec_b: np.ndarray) -> float:
+    """
+    Cosine similarity manually — dot product divided by product of magnitudes.
+    Score range: 0.0 to 1.0 (same meaning)
+    """
+    dot = np.dot(vec_a, vec_b)
+    norm = np.linalg.norm(vec_a) * np.linalg.norm(vec_b)
+    if norm == 0:
+        return 0.0
+    return float(dot / norm)
+
+
+def _score_to_tier(score: float) -> str:
+    """
+    Numeric score ko human-readable tier mein convert karo.
+    Thresholds rough hain — real usage se tune karna padega.
+    """
+    if score >= 0.55:
+        return "strong"
+    elif score >= 0.40:
+        return "moderate"
+    else:
+        return "weak"
+
+
+def rank_jobs(
+    jobs: List[Dict[str, Any]],
+    resume_text: str,
+) -> List[Dict[str, Any]]:
+    """
+    Main function jo main.py call karega.
+    
+    Input:  jobs list (DB se aaya, plain dicts) + resume text string
+    Output: same jobs list, match_score aur match_tier , sorted by score
+    
+    
+    """
+    model = _get_model()
+    
+    
+    if model is None:
+        logger.warning("Matcher unavailable — returning jobs unranked")
+        return jobs
+    
+    if not resume_text or not resume_text.strip():
+        logger.warning("Empty resume text — returning jobs unranked")
+        return jobs
+    
+    # Resume embedding — cached 
+    resume_vec = _get_resume_embedding(model, resume_text)
+    
+    
+    jd_texts = [_build_jd_text(job) for job in jobs]
+    jd_vectors = model.encode(jd_texts, convert_to_numpy=True, batch_size=32)
+    
+    
+    scored_jobs = []
+    for job, jd_vec in zip(jobs, jd_vectors):
+        score = _cosine_similarity(resume_vec, jd_vec)
+        scored_jobs.append({
+            **job,                          # original job dict
+            "match_score": round(score, 4),
+            "match_tier": _score_to_tier(score),
+        })
+    
+    #
+    scored_jobs.sort(key=lambda j: j["match_score"], reverse=True)
+    
+    return scored_jobs

--- a/aggregator-service/models.py
+++ b/aggregator-service/models.py
@@ -32,6 +32,8 @@ class JobOut(JobBase):
     id: UUID
     status: str
     created_at: datetime
+    match_score: Optional[float] = None
+    match_tier: Optional[str] = None
 
 
 class StatusUpdate(BaseModel):

--- a/aggregator-service/requirements.txt
+++ b/aggregator-service/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]>=0.29.0
 asyncpg>=0.29.0
 redis[asyncio]>=5.0.3
 pydantic>=2.7.0
+sentence-transformers>=2.7.0

--- a/aggregator-service/test_matcher.py
+++ b/aggregator-service/test_matcher.py
@@ -1,0 +1,70 @@
+
+from matcher import rank_jobs
+import time
+
+fake_jobs = [
+    {"id": "1", "company": "OpenAI", "role": "ML Research Engineer", "stack": ["Python", "PyTorch", "CUDA", "Transformers", "RLHF"], "product": "Large language model training infrastructure"},
+    {"id": "2", "company": "Zepto", "role": "Data Engineer", "stack": ["Spark", "Airflow", "dbt", "Snowflake", "SQL"], "product": "Real-time inventory and supply chain pipeline"},
+    {"id": "3", "company": "Razorpay", "role": "Backend Engineer", "stack": ["Go", "Kafka", "PostgreSQL", "Redis", "gRPC"], "product": "Payment gateway and transaction processing"},
+    {"id": "4", "company": "Sarvam AI", "role": "NLP Engineer - Indic Languages", "stack": ["Python", "HuggingFace", "IndicBERT", "FastAPI", "Transformers"], "product": "Hindi and Tamil speech-to-text and translation models"},
+    {"id": "5", "company": "CRED", "role": "Frontend Engineer", "stack": ["React", "TypeScript", "GraphQL", "Tailwind"], "product": "Credit card rewards and financial dashboard"},
+    {"id": "6", "company": "Anthropic", "role": "Safety Research Intern", "stack": ["Python", "PyTorch", "interpretability", "mechanistic analysis"], "product": "Constitutional AI and alignment research"},
+    {"id": "7", "company": "Swiggy", "role": "MLOps Engineer", "stack": ["Docker", "Kubernetes", "MLflow", "Seldon", "Python"], "product": "Model serving and deployment infrastructure"},
+    {"id": "8", "company": "Meesho", "role": "Computer Vision Engineer", "stack": ["Python", "OpenCV", "YOLOv8", "TensorFlow", "AWS"], "product": "Product image quality and catalogue tagging"},
+]
+
+resume = """
+3rd year Computer Science student specializing in Machine Learning and NLP.
+Experience building text classification pipelines using HuggingFace Transformers and PyTorch.
+Worked on Hindi language models and multilingual NLP tasks including named entity recognition.
+Built a YOLOv8-based image classifier for accident severity detection.
+Familiar with FastAPI for model deployment and basic Docker containerization.
+Contributed to open source ML projects on GitHub.
+Strong in Python, comfortable with scikit-learn, NumPy, and pandas.
+"""
+
+print("\n========== TEST 1: RANKED OUTPUT ==========")
+start = time.time()
+results = rank_jobs(fake_jobs, resume)
+elapsed = time.time() - start
+
+for i, job in enumerate(results, 1):
+    tier = job.get('match_tier', 'N/A')
+    score = job.get('match_score', 'N/A')
+    print(f"#{i:2}  {tier.upper():8} | score: {score} | {job['role']} at {job['company']}")
+
+scores = [j['match_score'] for j in results]
+print(f"\nRanking time : {elapsed:.2f}s")
+print(f"Score range  : {min(scores)} — {max(scores)}")
+print(f"Avg score    : {round(sum(scores)/len(scores), 4)}")
+gap = round(results[0]['match_score'] - results[1]['match_score'], 4)
+print(f"#1 vs #2 gap : {gap} {'(clear winner)' if gap > 0.05 else '(close race)'}")
+
+print("\n========== TEST 2: CACHE CHECK ==========")
+start2 = time.time()
+rank_jobs(fake_jobs, resume)
+elapsed2 = time.time() - start2
+print(f"First run  : {elapsed:.2f}s")
+print(f"Second run : {elapsed2:.2f}s")
+print(f"Cache      : {'YES ✅' if elapsed2 < elapsed else 'CHECK MANUALLY'}")
+
+print("\n========== TEST 3: NO RESUME CHECK ==========")
+results_empty = rank_jobs(fake_jobs, None)
+has_scores = any('match_score' in j for j in results_empty)
+print(f"Scores present without resume : {has_scores} (should be False)")
+print(f"No crash                      : ✅")
+
+print("\n========== TEST 4: ACCURACY CHECK ==========")
+top3 = [r['role'] for r in results[:3]]
+expected_top = {"ML Research Engineer", "NLP Engineer - Indic Languages", "Computer Vision Engineer"}
+got_top = set(top3)
+print(f"Expected top 3 : {expected_top}")
+print(f"Got top 3      : {got_top}")
+print(f"Top 3 check    : {'PASS ✅' if expected_top == got_top else 'FAIL ❌'}")
+
+bottom2 = [r['role'] for r in results[-2:]]
+expected_bottom = {"Frontend Engineer", "Backend Engineer"}
+got_bottom = set(bottom2)
+print(f"\nExpected bottom 2 : {expected_bottom}")
+print(f"Got bottom 2      : {got_bottom}")
+print(f"Bottom check      : {'PASS ✅' if expected_bottom == got_bottom else 'FAIL ❌'}")


### PR DESCRIPTION
## What this PR does


Adds matcher.py — a new optional module that ranks jobs by semantic similarity to a user's resume using Sentence-BERT. When a resume query param is passed to GET /jobs, jobs are returned sorted by match_score (0.0–1.0) instead of date. When no resume is passed, behavior is identical to before — nothing breaks, nothing changes.
No frontend changes. No schema migrations. No changes to the consumer, scheduler, Redis layer, or any other service.

## Files changed 

aggregator-service/matcher.py --> New file — all SBERT logic lives here
aggregator-service/models.py --> Added match_score: Optional[float] and match_tier: Optional[str] to JobOut
aggregator-service/main.py --> Added optional resume query param to GET /jobs, 3-line ranking injection after DB fetch
aggregator-service/requirements.txt

## Model details 


- As mentioned about the model to be lighter. Have chosen sbert over tf-idf for semantic realtions. A resume mentioning "HuggingFace Transformers and PyTorch" correctly ranks an "NLP Engineer - Indic Languages" role above a "Backend Engineer" role even though the word overlap is zero.
- Keeping the other limitations in mind `all-MiniLM-L6-v2` is used . no gpu needed, model size around 80mb, model loading strategy lazy, not eager. 
- switching to `lifespan()` is kept simple , not architecturally messed up. 
- Jobs are batch-encoded in one model.encode() call (batch_size=32) not one by one.faster for large job lists.

## Tests: 

- [X] Ranking output NLP/ML resume against 8 varied jobs
- [X] Cache Check
- [X] Empty Resume / Failure Handling
- [X] Accuracy Check (Top Matches)
- [X] Accuracy Check (Worst Matches)


<img width="1013" height="532" alt="Screenshot 2026-06-06 at 1 33 13 AM" src="https://github.com/user-attachments/assets/81a6a0c6-64cf-4a91-85b7-d89ce6efad48" />

## How to test locally

`  pip install sentence-transformers
cd aggregator-service
python test_matcher_final.py  `

##Closes 

The above PR closes #75 

> It was wonderful contributing to this project. AI tools were used during development to assist with implementation and exploration, but I have a complete understanding of the code, architecture, and design decisions involved. Please review the contribution and let me know if there are any changes, improvements, or feedback.