### PR TITLE
feat: add Cutshort.io spider for startup job crawling

### DIFF
--- a/crawler-service/README.md
+++ b/crawler-service/README.md
@@ -178,6 +178,28 @@ class MySiteSpider(BaseStartupSpider):
                     stack=[],
                 )
 ```
+## Cutshort Spider
+
+The `cutshort` spider extracts startup job listings from Cutshort.io and follows the same architecture as the existing spiders in the crawler.
+
+### Integration
+
+The spider subclasses `BaseStartupSpider` and emits standard `JobItem` objects. Extracted jobs automatically pass through the existing filtering, deduplication, and processing pipelines without requiring additional configuration.
+
+### Selector Strategy
+
+- Job titles are extracted from JSON-LD `ItemList` data when available.
+- HTML title extraction is used as a fallback.
+- URLs are normalized using `response.urljoin()`.
+- Company names are extracted from image `alt` text with an `h3` fallback.
+- Location and stack fields use class-based selectors because no stable attributes such as `data-testid`, `aria-label`, or semantic tags were available during investigation.
+- Inline comments have been added around selectors that may require updates if the Cutshort UI changes.
+
+### Pagination / Infinite Scroll
+
+Traditional pagination links were not found during investigation.
+
+The spider currently extracts all job cards available in the loaded page response. Additional pagination or infinite-scroll endpoints were not exposed during testing.
 
 ---
 

--- a/crawler-service/crawler/spiders/cutshort_spider.py
+++ b/crawler-service/crawler/spiders/cutshort_spider.py
@@ -1,0 +1,83 @@
+import scrapy
+import json
+from crawler.spiders.base_spider import BaseStartupSpider
+from crawler.models import JobItem
+
+
+class CutshortSpider(BaseStartupSpider):
+    name = "cutshort"
+
+    def start_requests(self):
+        role_slug = self.settings.get("JOBSEEKER_ROLE", "python").lower().replace(" ", "-")
+        url = f"https://cutshort.io/jobs/{role_slug}-jobs"
+        yield scrapy.Request(url, callback=self.parse)
+
+    def parse(self, response):
+        # Extract job titles from JSON-LD ItemList (most stable source — changes rarely).
+        # Items have no URL field, so JSON-LD titles are matched to cards using their position in the list.
+        jsonld_titles = {}
+        for raw in response.css('script[type="application/ld+json"]::text').getall():
+            try:
+                data = json.loads(raw)
+                if data.get("@type") == "ItemList":
+                    for item in data.get("itemListElement", []):
+                        pos = item.get("position")
+                        name = item.get("name", "").strip()
+                        if pos and name:
+                            jsonld_titles[pos] = name
+            except (json.JSONDecodeError, AttributeError):
+                pass
+
+        # No stable attributes (data-testid, aria-label, etc.) were found on job cards.
+        # Using a partial class match as the most reliable option available.
+        cards = response.css("div[class*='jEsvIv']")
+
+        if not cards:
+            self.logger.warning("No job cards found — jEsvIv selector may need updating")
+            return
+
+        for idx, card in enumerate(cards, start=1):
+            # URL: href pattern is stable, extracted from the job link.
+            # urljoin is used for consistency with other spiders.
+            role_url = card.css("a[href*='/job/']::attr(href)").get("")
+
+            # Role: Use JSON-LD as the primary source for job titles.
+            # Fall back to page HTML if JSON-LD is unavailable.
+            role_text = jsonld_titles.get(idx, "").strip()
+            if not role_text:
+                role_text = card.css("h2 a::text").get("").strip()
+
+            # Company: usually available in the image alt text.
+            # Fallback to h3 text if no logo/company image is present.
+            company = card.css("img::attr(alt)").get("").strip()
+            if not company:
+                company = card.css("h3::text").get("").strip()
+
+            # Location: No stable selector was found for location..
+            # Using a class-based selector as the best available option.
+            # Update if Cutshort redesigns job card UI.
+            location = card.css("div[class*='loAaLs']::text").get("").strip()
+
+            # Stack: Extract listed skills/technologies from the job card.
+            # Using a class-based selector because no stable attribute was available.
+            # Update if Cutshort redesigns job card UI.
+            stack_tags = card.css("div[class*='lfkCpY'] span::text").getall()
+            stack_tags = [t.strip() for t in stack_tags if t.strip()]
+
+            if not role_text:
+                continue
+            if not self.role_matches(role_text):
+                continue
+            if stack_tags and not self.stack_matches(stack_tags):
+                continue
+
+            yield JobItem(
+                company=company,
+                role=role_text,
+                source=self.name,
+                url=response.urljoin(role_url),
+                stack=stack_tags,
+                product="",
+                location=location,
+                posted_at=None,
+            )


### PR DESCRIPTION
Closes #2
This PR adds a spider for Cutshort.io to crawl and extract startup job listings while following the existing crawler conventions and handling missing fields gracefully.

**Sample Payloads**
{
"company": "Leinex", 
"role": "Python GCP", 
"source": "cutshort", 
"url": "https://cutshort.io/job/Python-GCP-Hyderabad-Leinex-jAAD3zJl", 
"stack": ["Python", "Google Cloud Platform (GCP)", "Data processing", "Object Oriented Programming (OOPs)"], 
"product": "", 
"location": "Hyderabad", 
"posted_at": null
},

**Extraction Output Proof**

<img width="1008" height="350" alt="image" src="https://github.com/user-attachments/assets/92351abf-26b0-4afa-8e77-8e07adb76b67" />

*Highlights:*
- 2026-06-06 16:28:07 [scrapy.extensions.feedexport] INFO: Stored json feed (7 items) in: output.json
- 'downloader/response_status_count/200': 2,
- 'finish_reason': 'finished',
- 'item_scraped_count': 7,

*Key validation points from proof:*
- JSON feed successfully exported
- HTTP responses returned status 200
- Crawl completed successfully
- 7 matching items extracted during validation run

<img width="1551" height="706" alt="image" src="https://github.com/user-attachments/assets/ac25c01d-2a94-429b-a95e-146a2bbb568e" />


**Pagination / Infinite Scroll**

Cutshort does not expose traditional pagination links on the job listing page.
I inspected the listing page structure and observed that the available jobs are rendered within the current page load. During testing, the page returned a finite set of listings and did not expose additional pagination URLs that could be followed by the spider.
The current implementation extracts all job cards available on the loaded listing page.


**Selector Strategy**
- Job titles are extracted from JSON-LD ItemList data when available, with HTML title extraction used as a fallback.
- URLs are extracted from job links and normalized using response.urljoin() for consistency with existing spiders.
- Company names are extracted from image alt text with an h3 fallback.
- Location and stack fields use class-based selectors because no stable attributes such as data-testid, aria-label, or semantic tags were available after investigation.
- Class-based selectors are documented inline to simplify future maintenance if the Cutshort UI changes.


**Notes**
- Reuses the existing JobItem schema.
- Compatible with the existing deduplication pipeline.
- Includes fallback handling for missing title, company, stack, and location fields.
- JSON-LD title ordering was verified against rendered card ordering during testing.