### PR TITLE
feat: add platform-selection chips to scrape modal

### DIFF
--- a/gateway/dashboard.html
+++ b/gateway/dashboard.html
@@ -829,6 +829,9 @@
       text-transform: uppercase;
       letter-spacing: .06em;
       margin-bottom: 8px;
+      text-transform: uppercase;
+      letter-spacing: .06em;
+      margin-bottom: 8px;
     }
 
     .metric-value {
@@ -1333,6 +1336,7 @@
     </section>
 
   </div><!-- #main -->
+  </div><!-- #main -->
 
   <!-- DETAIL PANEL -->
   <div id="panel-backdrop"></div>
@@ -1362,6 +1366,24 @@
         <div class="field-group">
           <label>Stack (comma-separated)</label>
           <input type="text" id="scrape-stack" value="Python,Go,FastAPI" />
+        </div>
+        <div class="field-group">
+          <label>Platforms</label>
+          <div class="platform-chips" id="platform-chips">
+            <button type="button" class="platform-chip" data-platform="linkedin">
+              <span class="chip-icon">💼</span>LinkedIn<span class="chip-check">✓</span>
+            </button>
+            <button type="button" class="platform-chip" data-platform="internshala">
+              <span class="chip-icon">🎓</span>Internshala<span class="chip-check">✓</span>
+            </button>
+            <button type="button" class="platform-chip" data-platform="naukri">
+              <span class="chip-icon">🏢</span>Naukri<span class="chip-check">✓</span>
+            </button>
+            <button type="button" class="platform-chip" data-platform="unstop">
+              <span class="chip-icon">🚀</span>Unstop<span class="chip-check">✓</span>
+            </button>
+          </div>
+          <p class="scrape-all-hint" id="scrape-all-hint">No selection — all platforms will be scraped</p>
         </div>
       </div>
       <div class="modal-footer">
@@ -2458,10 +2480,19 @@
       const role  = document.getElementById('scrape-role').value.trim();
       const stack = document.getElementById('scrape-stack').value.split(',').map(s => s.trim()).filter(Boolean);
       if (!role) { toast('Enter a role first', 'error'); return; }
+
+      // Collect selected platforms; empty array = scrape-all (backend default)
+      const selectedChips = document.querySelectorAll('#platform-chips .platform-chip.active');
+      const platforms = selectedChips.length > 0
+        ? [...selectedChips].map(c => c.dataset.platform)
+        : [];
+
       scrapeModal.classList.remove('open');
       const btn = document.getElementById('modal-submit');
       btn.disabled = true;
-      const r = await apiFetch('/scrape', { method: 'POST', body: { role, stack } });
+      const body = { role, stack };
+      if (platforms.length > 0) body.platforms = platforms;
+      const r = await apiFetch('/scrape', { method: 'POST', body });
       btn.disabled = false;
       if (r !== null) toast('Scraping started — new jobs will appear in ~60 seconds', 'info', 6000);
     });

--- a/scraper-service/main.py
+++ b/scraper-service/main.py
@@ -69,6 +69,7 @@ app = FastAPI(
 class ScrapeRequest(BaseModel):
     role: str = "Backend Engineer"
     stack: list[str] = []
+    platforms: list[str] = []   # empty → scrape all platforms
 
 
 class ScrapeResponse(BaseModel):
@@ -96,12 +97,16 @@ class DorkDiscoverResponse(BaseModel):
 # Background scrape runner
 # ---------------------------------------------------------------------------
 
-async def _run_all_scrapers(role: str, stack: list[str]) -> None:
+async def _run_scrapers(role: str, stack: list[str], platforms: list[str]) -> None:
     """
-    Run all four scrapers concurrently then emit results to Redis.
+   
+    Run selected (or all) scrapers concurrently then emit results to Redis.
     Designed to be launched as a BackgroundTask so /scrape returns immediately.
+
+    ``platforms`` is a list of lowercase platform names; an empty list means
+    "scrape everything" (the legacy / default behaviour).
     """
-    scrapers = [
+    all_scrapers = [
         NaukriScraper(),
         LinkedInScraper(),
         IntershalaScraper(),
@@ -109,7 +114,20 @@ async def _run_all_scrapers(role: str, stack: list[str]) -> None:
         UnstopScraper(),
     ]
 
-    # Run all scrapers in parallel; capture per-scraper exceptions.
+    # Filter to requested platforms; default to all when nothing is specified.
+    if platforms:
+        requested = {p.lower() for p in platforms}
+        scrapers = [s for s in all_scrapers if s.source_name.lower() in requested]
+        if not scrapers:
+            logger.warning(
+                "No scrapers matched requested platforms %s — falling back to all.",
+                platforms,
+            )
+            scrapers = all_scrapers
+    else:
+        scrapers = all_scrapers
+
+    # Run selected scrapers in parallel; capture per-scraper exceptions.
     results = await asyncio.gather(
         *[s.scrape(role, stack) for s in scrapers],
         return_exceptions=True,
@@ -142,7 +160,10 @@ async def health():
 @app.post("/scrape", response_model=ScrapeResponse, tags=["scraping"])
 async def trigger_scrape(body: ScrapeRequest, background_tasks: BackgroundTasks):
     """
-    Trigger all platform scrapers concurrently in the background.
+    Trigger platform scrapers concurrently in the background.
+
+    If ``body.platforms`` is non-empty, only those platforms are scraped.
+    An empty (or omitted) ``platforms`` list scrapes all platforms (legacy behaviour).
     Returns immediately while scraping happens asynchronously.
     """
     background_tasks.add_task(_run_all_scrapers, body.role, body.stack)
@@ -181,3 +202,10 @@ async def discover_dorks(body: DorkDiscoverRequest):
             for candidate in response.candidates
         ],
     )
+    active_platforms = (
+        [p.lower() for p in body.platforms]
+        if body.platforms
+        else PLATFORMS
+    )
+    background_tasks.add_task(_run_scrapers, body.role, body.stack, body.platforms)
+    return ScrapeResponse(triggered=True, platforms=active_platforms)


### PR DESCRIPTION
## Request payload examples

# Scrape all (no selection):
POST /api/scrape
{"role": "Backend Engineer", "stack": ["Python"]}

# Scrape only LinkedIn + Naukri:
POST /api/scrape
{"role": "Backend Engineer", "stack": ["Python"], "platforms": ["linkedin", "naukri"]}

## Scrape-all fallback proof
No chips selected → body has no `platforms` key → backend defaults to all four scrapers.

## Selections persist during submission
JS reads active chips at click-time of "Start Scraping" button, not on modal open — 
so toggling chips then immediately submitting always reflects the current selection.